### PR TITLE
Add sample routing configuration and document schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,48 @@ sProx/
 This repository currently contains the directory scaffolding only. Upcoming tasks will
 introduce the Rust crate setup, configuration loader, and the core proxy pipeline.
 
+### Configuration
+
+A sample `config/routes.yaml` file is included to document the expected shape of routing
+rules. Each entry under `routes` defines a listener, the upstream origin it connects to,
+and optional transport toggles.
+
+```yaml
+routes:
+  - id: "vod-edge"
+    listen:
+      host: "0.0.0.0"
+      port: 8080
+    upstream:
+      origin: "https://origin.example.com/vod"
+      tls:
+        enabled: true
+        sni_hostname: "origin.example.com"
+        insecure_skip_verify: false
+      socks5:
+        enabled: false
+        address: "127.0.0.1:1080"
+    hls:
+      enabled: true
+      rewrite_playlist_urls: true
+      base_url: "https://cdn.example.com/hls/"
+```
+
+Schema highlights:
+
+- `listen.host` / `listen.port` – Address where sProx accepts incoming connections for
+  the route.
+- `upstream.origin` – The absolute URL for the backend service or packager.
+- `upstream.tls` – Controls upstream TLS negotiation. Set `enabled` to `true` when the
+  origin expects HTTPS, optionally override the `sni_hostname`, and use
+  `insecure_skip_verify` only for local testing where certificate validation should be
+  bypassed.
+- `upstream.socks5` – When `enabled`, outbound traffic is tunnelled through the provided
+  SOCKS5 proxy `address`. Username and password fields are available for authenticated
+  proxies.
+- `hls` – Toggle playlist-aware behaviour. Use `rewrite_playlist_urls` and `base_url` to
+  emit absolute URLs pointing at your CDN or edge. `allow_insecure_segments` (see sample)
+  can be flipped to permit mixed HTTP/HTTPS playlists during migrations.
 
 ## Development tooling
 

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,0 +1,47 @@
+# Sample routing configuration for sProx.
+# Copy this file and adjust values for your deployment. All durations are in milliseconds unless noted.
+routes:
+  - id: "vod-edge"
+    listen:
+      host: "0.0.0.0"
+      port: 8080
+    upstream:
+      origin: "https://origin.example.com/vod"
+      connect_timeout_ms: 2000
+      read_timeout_ms: 5000
+      tls:
+        enabled: true            # Toggle TLS when connecting to the upstream origin.
+        sni_hostname: "origin.example.com"  # Override the TLS SNI host if it differs from the origin.
+        insecure_skip_verify: false          # Set to true to skip certificate validation (not recommended in production).
+      socks5:
+        enabled: false           # Route outbound requests through a SOCKS5 proxy when true.
+        address: "127.0.0.1:1080" # SOCKS5 proxy endpoint in host:port format.
+        username: null           # Optional username for authenticated proxies.
+        password: null           # Optional password for authenticated proxies.
+    hls:
+      enabled: true              # Enable HLS-specific response handling (playlist rewriting, segment normalization, etc.).
+      rewrite_playlist_urls: true # Rewrites variant and segment URLs to the configured base_url.
+      base_url: "https://cdn.example.com/hls/" # Public base URL to emit inside generated playlists.
+      allow_insecure_segments: false # Allow http:// segment references even when upstream is https.
+  - id: "api-pass-through"
+    listen:
+      host: "127.0.0.1"
+      port: 9090
+    upstream:
+      origin: "http://internal-api.example.local"
+      connect_timeout_ms: 1000
+      read_timeout_ms: 3000
+      tls:
+        enabled: false           # Pure HTTP pass-through to an internal service.
+        sni_hostname: null
+        insecure_skip_verify: null
+      socks5:
+        enabled: false
+        address: null
+        username: null
+        password: null
+    hls:
+      enabled: false             # Leave disabled for non-streaming routes.
+      rewrite_playlist_urls: false
+      base_url: null
+      allow_insecure_segments: null


### PR DESCRIPTION
## Summary
- add a sample `config/routes.yaml` illustrating TLS, SOCKS5, and HLS options
- document the routing configuration schema in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daab2c28c0832893b927f7cfcba0de