### PR TITLE
Initialize environment bootstrap and tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tower = { version = "0.4", features = ["util"], optional = true }
 tracing = { version = "0.1", features = ["std"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }
 url = "=2.4.1"
+dotenvy = "0.15"
 
 [dev-dependencies]
 serde_json = { version = "1.0" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,35 @@
-fn main() {
-    println!("sProx scaffold - implementation pending");
+use anyhow::Context;
+use std::io::ErrorKind;
+use tracing_subscriber::EnvFilter;
+
+fn main() -> anyhow::Result<()> {
+    load_env_file()?;
+    init_tracing()?;
+
+    sprox::init_placeholder();
+
+    tracing::info!("sProx bootstrap complete");
+
+    Ok(())
+}
+
+fn load_env_file() -> anyhow::Result<()> {
+    match dotenvy::dotenv() {
+        Ok(_) => Ok(()),
+        Err(dotenvy::Error::Io(err)) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn init_tracing() -> anyhow::Result<()> {
+    let env_filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .context("failed to construct tracing filter")?;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(false)
+        .compact()
+        .try_init()
+        .context("failed to initialize tracing subscriber")
 }


### PR DESCRIPTION
## Summary
- load a `.env` file when available and initialize the tracing subscriber during binary startup
- add the `dotenvy` dependency and update the pinned Rust toolchain to 1.78 to stay compatible with the existing lockfile

## Testing
- `cargo fmt`
- `cargo check` *(fails: linker `ld` is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dab0521d6c83289cdc09f3883cfc1a