### PR TITLE
Remove lld linker flag requirement and fix build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
 [alias]
 fmt-check = "fmt --all -- --check"
 clippy-all = "clippy --all-targets --all-features -- -D warnings"
-
-[target.'cfg(unix)']
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use std::io::ErrorKind;
 use tracing_subscriber::EnvFilter;
 
@@ -6,7 +6,7 @@ fn main() -> anyhow::Result<()> {
     load_env_file()?;
     init_tracing()?;
 
-    sprox::init_placeholder();
+    sProx::init_placeholder();
 
     tracing::info!("sProx bootstrap complete");
 
@@ -31,5 +31,7 @@ fn init_tracing() -> anyhow::Result<()> {
         .with_target(false)
         .compact()
         .try_init()
-        .context("failed to initialize tracing subscriber")
+        .map_err(|err| anyhow!("failed to initialize tracing subscriber: {err}"))?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- remove the unix-specific `-fuse-ld=lld` rustflag from the workspace cargo configuration so the project can compile without lld
- fix the binary crate to call the library correctly and surface tracing initialization failures with `anyhow`

## Testing
- cargo fmt
- cargo check
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dab308e8008328b8f07f51596c3a21