### PR TITLE
Add shared app state module

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,11 @@
 //! Application builder module placeholder.
 
+use crate::state::AppState;
+
 /// Constructs the Axum router.
 ///
 /// This placeholder will be replaced in subsequent tasks once the
 /// configuration loader and application state are implemented.
-pub fn build_router_placeholder() {
+pub fn build_router_placeholder(_state: AppState) {
     // TODO: Implement Axum router initialization.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! workspace compiles while feature-gated dependencies are wired up.
 
 pub mod app;
+pub mod state;
 
 /// Initializes crate-level resources. The implementation will be
 /// provided in later steps once configuration loading and telemetry are

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,152 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+/// Identifier used to look up cached client metadata.
+pub type ClientId = String;
+
+/// Identifier used to look up routing entries.
+pub type RouteId = String;
+
+/// Identifier used to look up secret values.
+pub type SecretName = String;
+
+/// Representation of a downstream client registered with the proxy.
+#[derive(Debug, Clone, Default)]
+pub struct ClientMetadata {
+    /// Arbitrary metadata describing a client; stored as key-value pairs so
+    /// integrators can extend the schema without requiring code changes.
+    pub attributes: HashMap<String, String>,
+}
+
+/// Representation of an upstream target used when proxying requests.
+#[derive(Debug, Clone, Default)]
+pub struct RouteTarget {
+    /// Endpoint of the upstream target. The placeholder is a bare string until
+    /// connection pooling and TLS configuration are implemented.
+    pub upstream: String,
+}
+
+/// Representation of an opaque secret loaded from the configuration backend.
+#[derive(Debug, Clone, Default)]
+pub struct SecretValue {
+    /// Raw secret value. Concrete projects may want to wrap this in a
+    /// redaction-friendly type but for now a string keeps the placeholder
+    /// ergonomic.
+    pub value: String,
+}
+
+/// In-memory cache used to store client registrations.
+pub type ClientsCache = HashMap<ClientId, ClientMetadata>;
+
+/// In-memory routing table mapping proxy routes to upstream targets.
+pub type RoutingTable = HashMap<RouteId, RouteTarget>;
+
+/// In-memory secret store shared across the application.
+pub type SecretsStore = HashMap<SecretName, SecretValue>;
+
+/// Shared handle to the client cache protected by an asynchronous lock.
+pub type SharedClientsCache = Arc<RwLock<ClientsCache>>;
+
+/// Shared handle to the routing table protected by an asynchronous lock.
+pub type SharedRoutingTable = Arc<RwLock<RoutingTable>>;
+
+/// Shared handle to the secret store protected by an asynchronous lock.
+pub type SharedSecretsStore = Arc<RwLock<SecretsStore>>;
+
+/// Top-level application state shared across the Axum router and background
+/// workers.
+#[derive(Clone, Debug)]
+pub struct AppState {
+    clients_cache: SharedClientsCache,
+    routing_table: SharedRoutingTable,
+    secrets: SharedSecretsStore,
+}
+
+impl AppState {
+    /// Constructs a new [`AppState`] using empty caches for each component.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Constructs a new [`AppState`] using the provided shared components. This
+    /// makes it easy to plug in pre-populated caches during bootstrap while
+    /// allowing handlers to share the same view of the data.
+    pub fn with_components(
+        clients_cache: SharedClientsCache,
+        routing_table: SharedRoutingTable,
+        secrets: SharedSecretsStore,
+    ) -> Self {
+        Self {
+            clients_cache,
+            routing_table,
+            secrets,
+        }
+    }
+
+    /// Returns a clone of the shared clients cache handle.
+    pub fn clients_cache(&self) -> SharedClientsCache {
+        Arc::clone(&self.clients_cache)
+    }
+
+    /// Returns a clone of the shared routing table handle.
+    pub fn routing_table(&self) -> SharedRoutingTable {
+        Arc::clone(&self.routing_table)
+    }
+
+    /// Returns a clone of the shared secrets store handle.
+    pub fn secrets(&self) -> SharedSecretsStore {
+        Arc::clone(&self.secrets)
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            clients_cache: Arc::new(RwLock::new(HashMap::new())),
+            routing_table: Arc::new(RwLock::new(HashMap::new())),
+            secrets: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn app_state_exposes_shared_handles() {
+        let state = AppState::new();
+
+        state.clients_cache().write().await.insert(
+            "client-a".into(),
+            ClientMetadata {
+                attributes: HashMap::from([(String::from("plan"), String::from("premium"))]),
+            },
+        );
+
+        let cached = state.clients_cache().read().await;
+        assert!(cached.contains_key("client-a"));
+
+        state.routing_table().write().await.insert(
+            "route-a".into(),
+            RouteTarget {
+                upstream: "https://example.com".into(),
+            },
+        );
+
+        let routes = state.routing_table().read().await;
+        assert_eq!(routes["route-a"].upstream, "https://example.com");
+
+        state.secrets().write().await.insert(
+            "api_key".into(),
+            SecretValue {
+                value: "super-secret".into(),
+            },
+        );
+
+        let secrets = state.secrets().read().await;
+        assert_eq!(secrets["api_key"].value, "super-secret");
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a state module that captures shared caches for clients, routing, and secrets
- expose the new module from the crate and require application builders to receive it

## Testing
- cargo fmt
- cargo check
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dab51eac2483288279983315e227f8