### PR TITLE
Implement Axum application builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ config-loader = [
 telemetry = [
     "dep:tracing",
     "dep:tracing-subscriber",
+    "dep:tower-http",
 ]
 
 # Feature flag placeholders for upcoming media tooling.
@@ -49,6 +50,7 @@ serde_yaml = { version = "0.9", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.38", features = ["rt-multi-thread", "macros", "signal"] }
 tower = { version = "0.4", features = ["util"], optional = true }
+tower-http = { version = "0.5", features = ["trace"], optional = true }
 tracing = { version = "0.1", features = ["std"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }
 url = "=2.4.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,127 @@
-//! Application builder module placeholder.
+//! Axum application builder utilities.
+//!
+//! This module wires together the top-level router used by the proxy. The
+//! implementation intentionally keeps the handlers lightweight; most of the
+//! logic is expected to live in dedicated modules that will be added in later
+//! steps of the project plan.
+
+use axum::{
+    extract::State,
+    http::{StatusCode, Uri},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+
+#[cfg(feature = "telemetry")]
+use tower_http::trace::TraceLayer;
 
 use crate::state::AppState;
 
-/// Constructs the Axum router.
+/// Constructs the Axum router used by the proxy.
 ///
-/// This placeholder will be replaced in subsequent tasks once the
-/// configuration loader and application state are implemented.
-pub fn build_router_placeholder(_state: AppState) {
-    // TODO: Implement Axum router initialization.
+/// The router currently exposes placeholder handlers that keep the
+/// application compiling while the downstream proxying logic is being
+/// implemented. Middlewares that are part of the final design, such as request
+/// tracing and rate limiting, are already attached so that the surrounding
+/// wiring can be validated ahead of time.
+pub fn build_router(state: AppState) -> Router {
+    let router = Router::new()
+        .route("/health", get(health_check))
+        .route("/ip", get(report_client_ip))
+        .route("/speedtest", get(speedtest_placeholder))
+        .route("/keys", get(list_registered_keys))
+        .fallback(proxy_fallback)
+        .with_state(state)
+        .layer(RateLimitLayer::default());
+
+    #[cfg(feature = "telemetry")]
+    let router = router.layer(TraceLayer::new_for_http());
+
+    router
+}
+
+/// Basic health-check handler used for readiness probes.
+async fn health_check() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+/// Returns a placeholder message for the caller's IP address.
+async fn report_client_ip() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        "IP discovery is not yet implemented. This is a placeholder response.",
+    )
+}
+
+/// Placeholder speed-test handler.
+async fn speedtest_placeholder() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        "Speedtest endpoint is not yet available. Please try again later.",
+    )
+}
+
+/// Lists the keys currently registered in the application's secret store.
+async fn list_registered_keys(State(state): State<AppState>) -> impl IntoResponse {
+    let secrets_store = state.secrets();
+    let secrets = secrets_store.read().await;
+    let mut keys: Vec<_> = secrets.keys().cloned().collect();
+    keys.sort();
+
+    if keys.is_empty() {
+        (
+            StatusCode::OK,
+            "No keys have been registered with the proxy at this time.".into(),
+        )
+    } else {
+        let response = format!("Registered keys: {}", keys.join(", "));
+        (StatusCode::OK, response)
+    }
+}
+
+/// Catch-all proxy handler used for routes that have not been explicitly
+/// registered.
+async fn proxy_fallback(State(state): State<AppState>, uri: Uri) -> impl IntoResponse {
+    let _ = state; // The state will be used once proxying is implemented.
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        format!("Proxying for `{uri}` has not been implemented yet."),
+    )
+}
+
+/// Placeholder layer representing the future rate-limiting middleware.
+#[derive(Clone, Default)]
+struct RateLimitLayer;
+
+impl<S> tower::Layer<S> for RateLimitLayer {
+    type Service = S;
+
+    fn layer(&self, service: S) -> Self::Service {
+        service
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt; // for `oneshot`
+
+    #[tokio::test]
+    async fn health_route_returns_success() {
+        let app = build_router(AppState::new());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }


### PR DESCRIPTION
## Summary
- add the tower-http dependency to wire telemetry tracing into the Axum stack
- replace the router placeholder with a builder that registers the health, ip, speedtest, keys, and proxy fallback routes
- scaffold placeholder handlers and middleware, including a rate limiting layer stub and a health route test

## Testing
- cargo fmt
- cargo check
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dab6ef2bf48328aaee1c4e32fa16cb