### PR TITLE
Add routing engine and tidy clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ axum = { version = "0.7", default-features = false, features = ["http1", "http2"
 bytes = { version = "1.5", optional = true }
 config = { version = "0.13", default-features = false, features = ["yaml", "toml"], optional = true }
 futures = "0.3"
+globset = "0.4"
 hyper = { version = "0.14", features = ["full"], optional = true }
 reqwest = { version = "=0.11.26", default-features = false, features = ["json", "stream"], optional = true }
 aes-gcm = { version = "0.10", features = ["aes"], optional = false }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -34,7 +34,7 @@ routes:
       tls:
         enabled: false           # Pure HTTP pass-through to an internal service.
         sni_hostname: null
-        insecure_skip_verify: null
+        insecure_skip_verify: false
       socks5:
         enabled: false
         address: null
@@ -44,4 +44,4 @@ routes:
       enabled: false             # Leave disabled for non-streaming routes.
       rewrite_playlist_urls: false
       base_url: null
-      allow_insecure_segments: null
+      allow_insecure_segments: false

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/keys", get(list_registered_keys))
         .fallback(proxy_fallback)
         .with_state(state)
-        .layer(RateLimitLayer::default());
+        .layer(RateLimitLayer);
 
     #[cfg(feature = "telemetry")]
     let router = router.layer(TraceLayer::new_for_http());

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,7 +132,7 @@ struct RawUpstream {
     socks5: RawSocks5,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct RawTls {
     #[serde(default)]
     enabled: bool,
@@ -142,17 +142,7 @@ struct RawTls {
     insecure_skip_verify: bool,
 }
 
-impl Default for RawTls {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            sni_hostname: None,
-            insecure_skip_verify: false,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct RawSocks5 {
     #[serde(default)]
     enabled: bool,
@@ -164,16 +154,7 @@ struct RawSocks5 {
     password: Option<String>,
 }
 
-impl Default for RawSocks5 {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            address: None,
-            username: None,
-            password: None,
-        }
-    }
-}
+// Default is derived above.
 
 #[derive(Debug, Deserialize)]
 struct RawHls {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 //! sProx library crate.
 //!
 //! The project currently exposes placeholder modules that will be
@@ -7,6 +9,7 @@
 pub mod app;
 #[cfg(feature = "config-loader")]
 pub mod config;
+pub mod routing;
 pub mod security;
 pub mod state;
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,339 @@
+use globset::{Glob, GlobMatcher};
+use std::fmt;
+use thiserror::Error;
+
+/// Supported application-layer protocols used when routing requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RouteProtocol {
+    Http,
+    Https,
+}
+
+impl RouteProtocol {
+    /// Builds a [`RouteProtocol`] from a URI scheme.
+    pub fn from_scheme(scheme: &str) -> Option<Self> {
+        match scheme.to_ascii_lowercase().as_str() {
+            "http" => Some(Self::Http),
+            "https" => Some(Self::Https),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RouteProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteProtocol::Http => write!(f, "http"),
+            RouteProtocol::Https => write!(f, "https"),
+        }
+    }
+}
+
+/// Inclusive port range matcher used by the routing engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortRange {
+    start: u16,
+    end: u16,
+}
+
+impl PortRange {
+    /// Constructs a new [`PortRange`].
+    pub fn new(start: u16, end: u16) -> Result<Self, RoutingError> {
+        if start > end {
+            return Err(RoutingError::InvalidPortRange { start, end });
+        }
+
+        Ok(Self { start, end })
+    }
+
+    /// Checks whether the provided port falls within the range.
+    pub fn contains(&self, port: u16) -> bool {
+        (self.start..=self.end).contains(&port)
+    }
+}
+
+/// Declarative route definition supplied by higher-level configuration loaders.
+#[derive(Debug, Clone)]
+pub struct RouteDefinition {
+    /// Stable identifier for the route.
+    pub id: String,
+    /// Hostname glob patterns matched against the incoming request's host.
+    pub host_patterns: Vec<String>,
+    /// Allowed protocols for the route. When empty, any protocol is accepted.
+    pub protocols: Vec<RouteProtocol>,
+    /// Allowed destination ports. When empty, any port is accepted.
+    pub ports: Vec<PortRange>,
+}
+
+impl RouteDefinition {
+    /// Convenience constructor used by tests to build a route matching any host/port/protocol.
+    pub fn any(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            host_patterns: Vec::new(),
+            protocols: Vec::new(),
+            ports: Vec::new(),
+        }
+    }
+}
+
+/// Request metadata used by the routing engine when selecting a route.
+#[derive(Debug, Clone, Copy)]
+pub struct RouteRequest<'a> {
+    /// Optional host header or SNI name.
+    pub host: Option<&'a str>,
+    /// Protocol negotiated with the downstream client.
+    pub protocol: RouteProtocol,
+    /// Local port that received the downstream connection.
+    pub port: u16,
+}
+
+/// Errors that can be emitted while constructing or evaluating the routing engine.
+#[derive(Debug, Error)]
+pub enum RoutingError {
+    #[error("invalid host glob `{pattern}`: {source}")]
+    InvalidHostGlob {
+        pattern: String,
+        #[source]
+        source: globset::Error,
+    },
+
+    #[error("port range start ({start}) must not be greater than end ({end})")]
+    InvalidPortRange { start: u16, end: u16 },
+}
+
+/// Top-level routing engine that selects the first matching route for a request.
+#[derive(Debug)]
+pub struct RoutingEngine {
+    routes: Vec<CompiledRoute>,
+}
+
+impl RoutingEngine {
+    /// Compiles the provided route definitions into runtime matchers.
+    pub fn new(routes: Vec<RouteDefinition>) -> Result<Self, RoutingError> {
+        let mut compiled = Vec::with_capacity(routes.len());
+        for definition in routes {
+            compiled.push(CompiledRoute::new(definition)?);
+        }
+
+        Ok(Self { routes: compiled })
+    }
+
+    /// Returns the first route matching the provided request metadata.
+    pub fn match_request(&self, request: &RouteRequest<'_>) -> Option<&RouteDefinition> {
+        self.routes
+            .iter()
+            .find(|route| route.matches(request))
+            .map(|route| &route.definition)
+    }
+}
+
+#[derive(Debug)]
+struct CompiledRoute {
+    definition: RouteDefinition,
+    host_matchers: Vec<GlobMatcher>,
+}
+
+impl CompiledRoute {
+    fn new(definition: RouteDefinition) -> Result<Self, RoutingError> {
+        let mut host_matchers = Vec::with_capacity(definition.host_patterns.len());
+        for pattern in &definition.host_patterns {
+            let glob = Glob::new(pattern)
+                .map_err(|source| RoutingError::InvalidHostGlob {
+                    pattern: pattern.clone(),
+                    source,
+                })?
+                .compile_matcher();
+            host_matchers.push(glob);
+        }
+
+        Ok(Self {
+            definition,
+            host_matchers,
+        })
+    }
+
+    fn matches(&self, request: &RouteRequest<'_>) -> bool {
+        self.protocol_matches(request)
+            && self.port_matches(request.port)
+            && self.host_matches(request.host)
+    }
+
+    fn protocol_matches(&self, request: &RouteRequest<'_>) -> bool {
+        if self.definition.protocols.is_empty() {
+            return true;
+        }
+
+        self.definition
+            .protocols
+            .iter()
+            .any(|protocol| *protocol == request.protocol)
+    }
+
+    fn port_matches(&self, port: u16) -> bool {
+        if self.definition.ports.is_empty() {
+            return true;
+        }
+
+        self.definition
+            .ports
+            .iter()
+            .any(|range| range.contains(port))
+    }
+
+    fn host_matches(&self, host: Option<&str>) -> bool {
+        if self.host_matchers.is_empty() {
+            return true;
+        }
+
+        let Some(host) = host else {
+            return false;
+        };
+
+        let normalized = host.trim_end_matches('.').to_ascii_lowercase();
+
+        self.host_matchers
+            .iter()
+            .any(|matcher| matcher.is_match(&normalized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_request(host: Option<&str>, protocol: RouteProtocol, port: u16) -> RouteRequest<'_> {
+        RouteRequest {
+            host,
+            protocol,
+            port,
+        }
+    }
+
+    #[test]
+    fn selects_first_matching_route() {
+        let routes = vec![
+            RouteDefinition {
+                id: "first".into(),
+                host_patterns: vec!["*.example.com".into()],
+                protocols: vec![RouteProtocol::Https],
+                ports: vec![PortRange::new(443, 443).unwrap()],
+            },
+            RouteDefinition::any("fallback"),
+        ];
+
+        let engine = RoutingEngine::new(routes).expect("routing engine should compile");
+        let request = build_request(Some("video.example.com"), RouteProtocol::Https, 443);
+
+        let route = engine
+            .match_request(&request)
+            .expect("a route should be selected");
+
+        assert_eq!(route.id, "first");
+    }
+
+    #[test]
+    fn falls_back_when_host_is_missing() {
+        let routes = vec![
+            RouteDefinition {
+                id: "hosted".into(),
+                host_patterns: vec!["*.example.com".into()],
+                protocols: vec![RouteProtocol::Http],
+                ports: vec![PortRange::new(80, 80).unwrap()],
+            },
+            RouteDefinition::any("default"),
+        ];
+
+        let engine = RoutingEngine::new(routes).expect("routing engine should compile");
+        let request = build_request(None, RouteProtocol::Http, 80);
+
+        let route = engine
+            .match_request(&request)
+            .expect("a fallback route should be selected");
+
+        assert_eq!(route.id, "default");
+    }
+
+    #[test]
+    fn rejects_invalid_glob_patterns() {
+        let routes = vec![RouteDefinition {
+            id: "bad".into(),
+            host_patterns: vec!["[".into()],
+            protocols: vec![],
+            ports: vec![],
+        }];
+
+        let err = RoutingEngine::new(routes).expect_err("glob compilation should fail");
+        matches!(err, RoutingError::InvalidHostGlob { .. });
+    }
+
+    #[test]
+    fn rejects_invalid_port_ranges() {
+        assert!(matches!(
+            PortRange::new(100, 10),
+            Err(RoutingError::InvalidPortRange {
+                start: 100,
+                end: 10
+            })
+        ));
+    }
+
+    #[test]
+    fn matches_multiple_protocols_and_ports() {
+        let routes = vec![RouteDefinition {
+            id: "multi".into(),
+            host_patterns: vec!["*.example.net".into()],
+            protocols: vec![RouteProtocol::Http, RouteProtocol::Https],
+            ports: vec![
+                PortRange::new(80, 80).unwrap(),
+                PortRange::new(8080, 8088).unwrap(),
+            ],
+        }];
+
+        let engine = RoutingEngine::new(routes).expect("routing engine should compile");
+
+        assert!(engine
+            .match_request(&build_request(
+                Some("edge.example.net"),
+                RouteProtocol::Http,
+                8080,
+            ))
+            .is_some());
+
+        assert!(engine
+            .match_request(&build_request(
+                Some("edge.example.net"),
+                RouteProtocol::Https,
+                80,
+            ))
+            .is_some());
+
+        assert!(engine
+            .match_request(&build_request(
+                Some("edge.example.net"),
+                RouteProtocol::Https,
+                8085,
+            ))
+            .is_some());
+    }
+
+    #[test]
+    fn normalizes_trailing_dot_in_hostnames() {
+        let routes = vec![RouteDefinition {
+            id: "edge".into(),
+            host_patterns: vec!["origin.example.org".into()],
+            protocols: vec![RouteProtocol::Https],
+            ports: vec![PortRange::new(443, 443).unwrap()],
+        }];
+
+        let engine = RoutingEngine::new(routes).expect("routing engine should compile");
+
+        assert!(engine
+            .match_request(&build_request(
+                Some("origin.example.org."),
+                RouteProtocol::Https,
+                443,
+            ))
+            .is_some());
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -126,7 +126,8 @@ mod tests {
             },
         );
 
-        let cached = state.clients_cache().read().await;
+        let clients_handle = state.clients_cache();
+        let cached = clients_handle.read().await;
         assert!(cached.contains_key("client-a"));
 
         state.routing_table().write().await.insert(
@@ -136,7 +137,8 @@ mod tests {
             },
         );
 
-        let routes = state.routing_table().read().await;
+        let routing_handle = state.routing_table();
+        let routes = routing_handle.read().await;
         assert_eq!(routes["route-a"].upstream, "https://example.com");
 
         state.secrets().write().await.insert(
@@ -146,7 +148,8 @@ mod tests {
             },
         );
 
-        let secrets = state.secrets().read().await;
+        let secrets_handle = state.secrets();
+        let secrets = secrets_handle.read().await;
         assert_eq!(secrets["api_key"].value, "super-secret");
     }
 }


### PR DESCRIPTION
## Summary
- add a routing engine module that compiles host globs, validates ports, and picks the first matching route at runtime
- depend on globset and export the routing module so it can be used across the crate
- clean up clippy findings in helper modules and adjust the sample configuration values to match their defaults

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dac0380afc8328bd58e8f74a2da3e0