### PR TITLE
Add bandwidth limiter, IP cache, and base64 utilities

### DIFF
--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -1,0 +1,140 @@
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+/// Token bucket style limiter that caps the amount of data that can be
+/// processed within a fixed interval.
+///
+/// The implementation is intentionally lightweight; it is designed so the
+/// surrounding proxy stack can reason about bandwidth shaping behaviour without
+/// introducing external dependencies. Consumers can call [`try_acquire`] when
+/// best-effort throttling is sufficient or [`acquire`] to wait until enough
+/// capacity is available.
+#[derive(Debug)]
+pub struct BandwidthLimiter {
+    capacity: usize,
+    refill_interval: Duration,
+    inner: Mutex<LimiterState>,
+}
+
+#[derive(Debug)]
+struct LimiterState {
+    tokens: usize,
+    last_refill: Instant,
+}
+
+impl BandwidthLimiter {
+    /// Creates a new limiter that grants up to `capacity` units within the
+    /// configured `refill_interval`.
+    pub fn new(capacity: usize, refill_interval: Duration) -> Self {
+        assert!(capacity > 0, "limiter capacity must be non-zero");
+        assert!(
+            refill_interval > Duration::ZERO,
+            "refill interval must be > 0"
+        );
+
+        Self {
+            capacity,
+            refill_interval,
+            inner: Mutex::new(LimiterState {
+                tokens: capacity,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+
+    fn refill(&self, state: &mut LimiterState, now: Instant) {
+        if now.saturating_duration_since(state.last_refill) >= self.refill_interval {
+            state.tokens = self.capacity;
+            state.last_refill = now;
+        }
+    }
+
+    /// Attempts to immediately reserve `amount` units from the limiter.
+    ///
+    /// Returns `true` when enough capacity was available.
+    pub async fn try_acquire(&self, amount: usize) -> bool {
+        if amount > self.capacity {
+            return false;
+        }
+
+        let mut state = self.inner.lock().await;
+        let now = Instant::now();
+        self.refill(&mut state, now);
+
+        if state.tokens >= amount {
+            state.tokens -= amount;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Reserves `amount` units from the limiter, waiting until the quota is
+    /// replenished if necessary.
+    pub async fn acquire(&self, amount: usize) {
+        assert!(amount <= self.capacity, "request exceeds limiter capacity");
+
+        loop {
+            if self.try_acquire(amount).await {
+                return;
+            }
+
+            let sleep_duration = self.time_until_refill().await;
+            tokio::time::sleep(sleep_duration).await;
+        }
+    }
+
+    async fn time_until_refill(&self) -> Duration {
+        let mut state = self.inner.lock().await;
+        let now = Instant::now();
+        self.refill(&mut state, now);
+        let elapsed = now.saturating_duration_since(state.last_refill);
+
+        if elapsed >= self.refill_interval {
+            Duration::ZERO
+        } else {
+            self.refill_interval - elapsed
+        }
+    }
+
+    /// Returns the remaining quota for the current interval.
+    pub async fn remaining(&self) -> usize {
+        let mut state = self.inner.lock().await;
+        let now = Instant::now();
+        self.refill(&mut state, now);
+        state.tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn limiter_rejects_when_capacity_exhausted() {
+        let limiter = BandwidthLimiter::new(10, Duration::from_millis(50));
+        assert!(limiter.try_acquire(5).await);
+        assert!(limiter.try_acquire(5).await);
+        assert!(!limiter.try_acquire(1).await);
+    }
+
+    #[tokio::test]
+    async fn limiter_waits_for_refill() {
+        let limiter = BandwidthLimiter::new(4, Duration::from_millis(10));
+        limiter.acquire(4).await;
+        let start = Instant::now();
+        limiter.acquire(2).await;
+        assert!(start.elapsed() >= Duration::from_millis(10));
+    }
+
+    #[tokio::test]
+    async fn remaining_updates_after_refill() {
+        let limiter = BandwidthLimiter::new(3, Duration::from_millis(5));
+        limiter.acquire(3).await;
+        assert_eq!(limiter.remaining().await, 0);
+        sleep(Duration::from_millis(5)).await;
+        assert_eq!(limiter.remaining().await, 3);
+    }
+}

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,0 +1,128 @@
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+/// Time-to-live aware cache used for storing the proxy's public IP address.
+///
+/// The cache is intentionally backend agnostic: callers provide an asynchronous
+/// fetcher when a refresh is required. This keeps the module straightforward to
+/// test while still allowing integration with HTTP based discovery services.
+#[derive(Debug)]
+pub struct PublicIpCache {
+    ttl: Duration,
+    inner: Mutex<Option<CacheEntry>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CacheEntry {
+    value: IpAddr,
+    fetched_at: Instant,
+}
+
+impl PublicIpCache {
+    /// Creates a new cache with the provided time-to-live.
+    pub fn new(ttl: Duration) -> Self {
+        assert!(ttl > Duration::ZERO, "cache TTL must be greater than zero");
+
+        Self {
+            ttl,
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Returns the cached value if it is still fresh.
+    pub async fn get(&self) -> Option<IpAddr> {
+        let guard = self.inner.lock().await;
+        guard.as_ref().and_then(|entry| {
+            if entry.fetched_at.elapsed() <= self.ttl {
+                Some(entry.value)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Retrieves the cached public IP address, refreshing it via `fetcher`
+    /// when the cache has expired.
+    pub async fn get_or_update<E, F, Fut>(&self, fetcher: F) -> Result<IpAddr, E>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<IpAddr, E>>,
+    {
+        if let Some(value) = self.get().await {
+            return Ok(value);
+        }
+
+        let value = fetcher().await?;
+        let mut guard = self.inner.lock().await;
+        *guard = Some(CacheEntry {
+            value,
+            fetched_at: Instant::now(),
+        });
+
+        Ok(value)
+    }
+
+    /// Invalidates the cached value, forcing the next lookup to invoke the
+    /// provided fetcher.
+    pub async fn invalidate(&self) {
+        let mut guard = self.inner.lock().await;
+        guard.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn cache_returns_existing_value() {
+        let cache = PublicIpCache::new(Duration::from_millis(20));
+        let ip: IpAddr = Ipv4Addr::new(192, 168, 1, 1).into();
+        cache
+            .get_or_update(|| async { Ok::<_, ()>(ip) })
+            .await
+            .unwrap();
+
+        let cached = cache.get().await;
+        assert_eq!(cached, Some(ip));
+    }
+
+    #[tokio::test]
+    async fn cache_refreshes_after_ttl() {
+        let cache = PublicIpCache::new(Duration::from_millis(10));
+        let first: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let second: IpAddr = Ipv4Addr::new(10, 0, 0, 2).into();
+
+        let value = cache
+            .get_or_update(|| async { Ok::<_, ()>(first) })
+            .await
+            .unwrap();
+        assert_eq!(value, first);
+
+        sleep(Duration::from_millis(15)).await;
+
+        let value = cache
+            .get_or_update(|| async { Ok::<_, ()>(second) })
+            .await
+            .unwrap();
+        assert_eq!(value, second);
+    }
+
+    #[tokio::test]
+    async fn invalidate_clears_cache() {
+        let cache = PublicIpCache::new(Duration::from_secs(1));
+        let ip: IpAddr = Ipv4Addr::new(203, 0, 113, 1).into();
+
+        cache
+            .get_or_update(|| async { Ok::<_, ()>(ip) })
+            .await
+            .unwrap();
+
+        cache.invalidate().await;
+        assert!(cache.get().await.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,16 @@
 //! workspace compiles while feature-gated dependencies are wired up.
 
 pub mod app;
+pub mod bandwidth;
 #[cfg(feature = "config-loader")]
 pub mod config;
+pub mod ip;
 pub mod proxy;
 pub mod routing;
 pub mod security;
 pub mod state;
 pub mod stream;
+pub mod util;
 
 /// Initializes crate-level resources. The implementation will be
 /// provided in later steps once configuration loading and telemetry are

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,88 @@
+use std::fmt;
+
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::Engine;
+
+/// Encodes the provided bytes using the standard Base64 alphabet.
+pub fn encode_base64<T: AsRef<[u8]>>(data: T) -> String {
+    STANDARD.encode(data)
+}
+
+/// Decodes a standard Base64 string into raw bytes.
+pub fn decode_base64(data: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    STANDARD.decode(data)
+}
+
+/// Encodes bytes using the URL-safe Base64 alphabet without padding.
+pub fn encode_base64_url<T: AsRef<[u8]>>(data: T) -> String {
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+/// Decodes a URL-safe Base64 string without padding.
+pub fn decode_base64_url(data: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    URL_SAFE_NO_PAD.decode(data)
+}
+
+/// Attempts to decode a Base64 string into UTF-8 text, returning a
+/// human-readable error on failure.
+pub fn decode_base64_to_string(data: &str) -> Result<String, Base64TextError> {
+    let bytes = decode_base64(data).map_err(Base64TextError::InvalidEncoding)?;
+    String::from_utf8(bytes).map_err(|err| Base64TextError::InvalidUtf8(err.utf8_error()))
+}
+
+/// Error returned when a Base64 string cannot be converted into UTF-8 text.
+#[derive(Debug)]
+pub enum Base64TextError {
+    /// The provided data was not valid Base64 encoded content.
+    InvalidEncoding(base64::DecodeError),
+    /// The decoded bytes were not valid UTF-8 text.
+    InvalidUtf8(std::str::Utf8Error),
+}
+
+impl fmt::Display for Base64TextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEncoding(err) => write!(f, "invalid base64 data: {err}"),
+            Self::InvalidUtf8(err) => write!(f, "decoded data is not valid UTF-8: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for Base64TextError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidEncoding(err) => Some(err),
+            Self::InvalidUtf8(err) => Some(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_standard_alphabet() {
+        let input = b"hello world";
+        let encoded = encode_base64(input);
+        let decoded = decode_base64(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn round_trip_url_alphabet() {
+        let input = b"binary\x00payload";
+        let encoded = encode_base64_url(input);
+        let decoded = decode_base64_url(&encoded).unwrap();
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn decode_to_string_reports_errors() {
+        let err = decode_base64_to_string("::not-valid::").unwrap_err();
+        match err {
+            Base64TextError::InvalidEncoding(_) => {}
+            _ => panic!("unexpected variant"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a token bucket based bandwidth limiter module with async acquisition helpers
- provide a TTL-aware public IP cache abstraction that supports async fetchers
- introduce base64 encoding/decoding helpers with ergonomic error reporting and expose the modules from the crate root

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dbc6121554832888f958be55d07364