### PR TITLE
docs: expand architecture and operations guidance

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,92 @@
+# Architecture overview
+
+This document expands on the high-level proxy architecture to illustrate the planned
+modules, data flow, and integration points. The implementation is still evolving; the
+structure below provides guidance for future development tasks.
+
+## Component map
+
+```
+                                        ┌──────────────────────┐
+                                        │    Config loader     │
+                                        │ (TOML/YAML/ENV merge)│
+                                        └──────────┬───────────┘
+                                                   │
+                                                   ▼
+┌──────────────────────┐    ┌──────────────────────┐    ┌──────────────────────────────┐
+│  Edge listeners      │    │  Middleware stack    │    │  Streaming transformation    │
+│  (Axum router)       │    │  (Tower layers)      │    │  (manifests, segments, DRM)  │
+└─────────┬────────────┘    └──────────┬───────────┘    └──────────────┬──────────────┘
+          │                             │                               │
+          ▼                             ▼                               ▼
+  Connection pool             Request context store              Manifest workers
+  TLS terminators             Auth & rate limiting               Segment fetchers
+          │                             │                               │
+          └─────────────┬───────────────┴───────────────┬───────────────┘
+                        ▼                               ▼
+                 Upstream dispatcher              Background jobs
+                 (hyper client pool)             (scheduler, cache)
+```
+
+### Edge listeners
+
+- Built on top of Axum/Tokio, exposing HTTP/1.1, HTTP/2, and eventually HTTP/3.
+- Performs connection upgrades (WebSocket) and handles graceful shutdown signals.
+- Relies on a TLS abstraction so routes can toggle termination independently.
+
+### Middleware stack
+
+- Tower layers enforce cross-cutting policies: authentication, request shaping,
+  observability, rate limiting, and header normalisation.
+- Provides structured logging, OpenTelemetry tracing, and metrics emission.
+- Maintains a request-scoped context object that downstream layers can inspect.
+
+### Streaming transformation layer
+
+- Contains protocol-specific handlers for HLS, DASH, CMAF, and future protocols.
+- Rewrites manifests (variant playlists, MPDs) to adjust CDN base URLs and inject DRM
+  descriptors.
+- Coordinates optional transmuxing pipelines using FFmpeg/Shaka Packager helpers in
+  `packagers/`.
+- Implements caching adaptors to reduce round-trips for popular manifests.
+
+### Background jobs and utilities
+
+- A lightweight scheduler runs periodic maintenance tasks (certificate renewal, cache
+  eviction, DRM key refresh).
+- Shared primitives live in `src/stream/` for parsing manifests, rewriting URLs, and
+  applying policy checks.
+- Telemetry exporters send metrics to Prometheus or StatsD; logs are structured (JSON) for
+  log aggregation systems.
+
+## Request lifecycle
+
+1. Listener accepts a client connection and negotiates TLS if enabled.
+2. Axum routes the incoming request based on path/prefix matches defined in the
+   configuration.
+3. Middleware stack authenticates the request, rate limits if necessary, and enriches
+   the context with metadata (device type, session ID, geolocation).
+4. Routing component selects the upstream origin and issues an outbound request using the
+   Hyper client pool. SOCKS5 tunnels or HTTP CONNECT proxies can be inserted here.
+5. Response flows through the streaming layer. If the payload is a manifest, it is parsed
+   and rewritten; otherwise it may be streamed back directly (for media segments).
+6. DRM hooks request keys or licenses when required, injecting the appropriate headers or
+   query parameters into manifests or responses.
+7. The transformed response is streamed back to the client with updated caching and
+   security headers.
+
+## Extensibility notes
+
+- New authentication mechanisms (e.g., JWT validation, OAuth token introspection) can be
+  added as Tower layers without modifying downstream code.
+- Additional manifest types should implement a common trait so they can be plugged into
+  the processing pipeline with minimal wiring changes.
+- Observability exporters should follow the OpenTelemetry standard to remain compatible
+  with multiple backends.
+
+## Future work
+
+- Pluggable policy engine for per-route authorisation rules.
+- Integrated configuration hot-reload with validation rollback support.
+- QUIC/HTTP3 listener implementation once the Rust ecosystem stabilises.
+- Auto-scaling recommendations based on telemetry trends and burst detection.

--- a/docs/operational-notes.md
+++ b/docs/operational-notes.md
@@ -1,0 +1,75 @@
+# Operational notes
+
+This guide summarises best practices for deploying, monitoring, and securing sProx in
+staging and production environments. Adjust the recommendations to fit your existing
+observability, compliance, and release management tooling.
+
+## Security posture
+
+- **Principle of least privilege** – Run the proxy under a dedicated system account with
+  restricted file system and network permissions. Allow outbound access only to
+  configured upstreams and required key servers.
+- **Secrets management** – Store TLS private keys, DRM credentials, and API tokens in a
+  secret manager (e.g., AWS Secrets Manager, HashiCorp Vault). Inject them at runtime via
+  environment variables rather than committing them to configuration files.
+- **Input validation** – Harden manifest parsers against malformed inputs. Reject paths
+  containing directory traversal sequences and normalise headers to avoid request
+  smuggling issues.
+- **Logging hygiene** – Never log tokens, DRM keys, or personally identifiable
+  information. Redact sensitive headers at the middleware layer.
+
+## TLS management
+
+- Terminate inbound TLS with modern cipher suites (TLS 1.2+) and enable HTTP/2 ALPN.
+- Use `config/listeners/*.yaml` to set per-route certificates when different hostnames are
+  served from the same cluster.
+- Monitor certificate expiry and automate renewal. Integrate with ACME or corporate PKI
+  using background jobs that place renewed keys in a hot-reloadable location.
+- Enforce strict transport security (HSTS) in client responses and consider enabling TLS
+  session resumption to reduce handshake overhead.
+
+## DRM and key services
+
+- Communicate with DRM backends over mutually authenticated TLS when available. This
+  protects against impersonation and replay attacks.
+- Cache DRM keys in memory for the minimum viable duration (e.g., per-request) and wipe
+  buffers after use.
+- Implement rate limits and anomaly detection on key requests to prevent abuse.
+- Keep packager integrations (FFmpeg/Shaka) patched to the latest security releases.
+
+## Observability
+
+- Emit structured logs (JSON) with request IDs, upstream latency, and manifest processing
+  metrics. Forward them to a central aggregation system (ELK, Loki, etc.).
+- Publish Prometheus metrics for request volume, response codes, TLS handshakes, manifest
+  rewrite timings, and DRM key lookup latency.
+- Trace end-to-end requests with OpenTelemetry (OTLP exporter). Include spans for
+  manifest parsing and upstream fetches to identify bottlenecks.
+
+## Deployment and operations
+
+- Use infrastructure-as-code (Terraform, Pulumi, CloudFormation) to provision listener
+  frontends, compute, and load balancers.
+- Implement blue/green or canary deployments. Validate new releases with synthetic HLS
+  playback tests before shifting traffic.
+- Configure autoscaling policies based on CPU, network throughput, and manifest
+  processing latency. For bursty events, consider pre-scaling nodes.
+- Maintain a runbook for incident response, including steps to rotate credentials, roll
+  back configurations, and drain traffic.
+
+## Disaster recovery
+
+- Store configuration and deployment artefacts in version control. Regularly back up
+  critical configuration to off-site storage.
+- Replicate the service across multiple availability zones or regions to reduce blast
+  radius during outages.
+- Document recovery time objectives (RTO) and recovery point objectives (RPO) for each
+  deployment environment. Test failover procedures at least once per quarter.
+
+## Local-to-production parity
+
+- Mirror production listener and upstream definitions in staging to detect manifest or DRM
+  regressions early.
+- Use feature flags for experimental manifest rewrites so they can be toggled without a
+  redeploy.
+- Keep configuration schemas synchronised across environments to avoid runtime surprises.

--- a/src/stream/dash.rs
+++ b/src/stream/dash.rs
@@ -360,6 +360,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use std::fmt::Write;
     use tower::ServiceExt;
 
     use crate::state::{AppState, SecretValue};
@@ -464,18 +465,18 @@ mod tests {
 
         let decoded_16 = decode_key_material(hex_16, key_name).expect("hex16 should decode");
         assert_eq!(decoded_16.len(), 16);
-        let encoded_16: String = decoded_16
-            .iter()
-            .map(|byte| format!("{:02x}", byte))
-            .collect();
+        let mut encoded_16 = String::with_capacity(decoded_16.len() * 2);
+        for byte in &decoded_16 {
+            write!(&mut encoded_16, "{:02x}", byte).expect("formatting hex");
+        }
         assert_eq!(encoded_16, hex_16);
 
         let decoded_32 = decode_key_material(hex_32, key_name).expect("hex32 should decode");
         assert_eq!(decoded_32.len(), 32);
-        let encoded_32: String = decoded_32
-            .iter()
-            .map(|byte| format!("{:02x}", byte))
-            .collect();
+        let mut encoded_32 = String::with_capacity(decoded_32.len() * 2);
+        for byte in &decoded_32 {
+            write!(&mut encoded_32, "{:02x}", byte).expect("formatting hex");
+        }
         assert_eq!(encoded_32, hex_32);
     }
 }


### PR DESCRIPTION
## Summary
- overhaul README with architecture overview, configuration guidance, operational notes, and local development workflow
- add dedicated architecture and operational reference documents under docs/
- update DASH test helpers to avoid format collection per clippy guidance

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dbcb8e8b2883289db483ea4197a616