### PR TITLE
Add helper packager scripts with DRM placeholders

### DIFF
--- a/packagers/README.md
+++ b/packagers/README.md
@@ -1,0 +1,53 @@
+# Packaging Helpers
+
+This directory provides thin wrappers around the packagers used by the
+streaming pipeline. Each script is intentionally verbose about the
+environment variables it expects so that the automation driving them can
+source values from a secrets manager or `.env` file.
+
+## `ffmpeg_packager.sh`
+
+Encrypts a mezzanine file using FFmpeg's Common Encryption support. The script
+expects the following variables to be exported before invocation:
+
+- `FFMPEG_BIN` *(optional)* – Path to the FFmpeg binary.
+- `FFMPEG_INPUT` – Absolute or relative path to the mezzanine input file.
+- `FFMPEG_OUTPUT_DIR` – Directory where encrypted assets will be stored.
+- `FFMPEG_VIDEO_BITRATE` *(optional)* – Target video bitrate (default: `3500k`).
+- `FFMPEG_AUDIO_BITRATE` *(optional)* – Target audio bitrate (default: `128k`).
+- `DRM_KEY_ID` – Hex-encoded key identifier (KID).
+- `DRM_KEY_HEX` – Hex-encoded AES key.
+- `DRM_IV_HEX` *(optional)* – Initialization vector override; defaults to all zeros.
+
+## `shaka_packager.sh`
+
+Creates DASH and HLS outputs using Shaka Packager with raw-key DRM. Expected
+variables include:
+
+- `SHAKA_BIN` *(optional)* – Path to the Shaka Packager binary.
+- `INPUT_VIDEO` – Video-only input file.
+- `INPUT_AUDIO` – Audio-only input file.
+- `OUTPUT_DIR` – Target directory for manifests and fragmented MP4 files.
+- `STREAM_LABEL` *(optional)* – Label assigned to the video stream (default: `video`).
+- `AUDIO_LABEL` *(optional)* – Label assigned to the audio stream (default: `audio`).
+- `PACKAGER_BASE_URL` *(optional)* – Base URL advertised in the generated manifests.
+- `DRM_KEY_ID` – Hex-encoded key identifier.
+- `DRM_KEY_HEX` – Hex-encoded AES key.
+- `DRM_PSSH_BASE64` *(optional)* – Base64 encoded custom PSSH box to embed.
+- `DRM_CONTENT_ID` *(optional)* – Identifier used in Widevine requests (default: `sprox-demo`).
+- `DRM_LICENSE_URL` – URL of the license proxy / DRM provider.
+
+Scripts can be invoked directly after exporting the variables or sourcing an
+`.env` file. Example:
+
+```bash
+export FFMPEG_INPUT=assets/mezzanine.mp4
+export FFMPEG_OUTPUT_DIR=./build/ffmpeg
+export DRM_KEY_ID=0123456789abcdef0123456789abcdef
+export DRM_KEY_HEX=abcdef0123456789abcdef0123456789
+./packagers/ffmpeg_packager.sh
+```
+
+Because the scripts use `set -euo pipefail`, they will fail fast whenever a
+required value is missing, preventing partially encrypted artifacts from being
+produced.

--- a/packagers/ffmpeg_packager.sh
+++ b/packagers/ffmpeg_packager.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper script for packaging media with FFmpeg while highlighting the
+# configuration that the rest of the pipeline expects. All variables below can
+# be sourced from an environment file (e.g. `source ./config/packaging.env`).
+
+: "${FFMPEG_BIN:=ffmpeg}"            # Override to point to a custom FFmpeg build
+: "${FFMPEG_INPUT:?Need to set FFMPEG_INPUT to the mezzanine file}" 
+: "${FFMPEG_OUTPUT_DIR:?Need to set FFMPEG_OUTPUT_DIR to the output directory}" 
+: "${FFMPEG_VIDEO_BITRATE:=3500k}"  # Example video bitrate
+: "${FFMPEG_AUDIO_BITRATE:=128k}"   # Example audio bitrate
+
+# DRM placeholders. Replace these with your Widevine/PlayReady keys or point
+# to a secrets manager before running the script.
+: "${DRM_KEY_ID:?Need to set DRM_KEY_ID}"         # e.g. 0123456789abcdef0123456789abcdef
+: "${DRM_KEY_HEX:?Need to set DRM_KEY_HEX}"       # Raw AES-128 key in hex
+: "${DRM_IV_HEX:=00000000000000000000000000000000}" # Optional IV override
+
+mkdir -p "${FFMPEG_OUTPUT_DIR}"
+
+"${FFMPEG_BIN}" \
+  -y \
+  -i "${FFMPEG_INPUT}" \
+  -c:v libx264 \
+  -b:v "${FFMPEG_VIDEO_BITRATE}" \
+  -c:a aac \
+  -b:a "${FFMPEG_AUDIO_BITRATE}" \
+  -movflags +faststart \
+  -encryption_scheme cenc-aes-ctr \
+  -encryption_key "${DRM_KEY_HEX}" \
+  -encryption_kid "${DRM_KEY_ID}" \
+  -encryption_iv "${DRM_IV_HEX}" \
+  "${FFMPEG_OUTPUT_DIR}/encrypted_output.mp4"
+
+cat <<INFO
+Packaging complete.
+Encrypted output stored at: ${FFMPEG_OUTPUT_DIR}/encrypted_output.mp4
+Used DRM key ID: ${DRM_KEY_ID}
+INFO

--- a/packagers/shaka_packager.sh
+++ b/packagers/shaka_packager.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper script to invoke Shaka Packager with Widevine-like placeholders.
+# Export the variables below or load them from your preferred secrets store
+# before running the script.
+
+: "${SHAKA_BIN:=packager}"             # Override to point to the packager binary
+: "${INPUT_VIDEO:?Set INPUT_VIDEO to the source video file}" 
+: "${INPUT_AUDIO:?Set INPUT_AUDIO to the source audio file}" 
+: "${OUTPUT_DIR:?Set OUTPUT_DIR to the directory for DASH/HLS outputs}" 
+: "${STREAM_LABEL:=video}"             # Label used in the manifest for video
+: "${AUDIO_LABEL:=audio}"              # Label used in the manifest for audio
+: "${PACKAGER_BASE_URL:=https://cdn.example.com/}" # Base URL advertised in the manifests
+
+# DRM placeholders. Replace these with the actual values provided by your DRM
+# provider. They can also be injected securely via environment variables in CI.
+: "${DRM_KEY_ID:?Set DRM_KEY_ID (hex)}"
+: "${DRM_KEY_HEX:?Set DRM_KEY_HEX (hex)}"
+: "${DRM_PSSH_BASE64:=}"               # Optional custom PSSH data (base64)
+: "${DRM_CONTENT_ID:=sprox-demo}"     # Used for Widevine license requests
+: "${DRM_LICENSE_URL:?Set DRM_LICENSE_URL}" # e.g. https://license.example.com
+
+mkdir -p "${OUTPUT_DIR}"
+
+COMMON_PARAMS=(
+  "--enable_raw_key_encryption"
+  "--key_id=${DRM_KEY_ID}"
+  "--key=${DRM_KEY_HEX}"
+  "--content_id=${DRM_CONTENT_ID}"
+  "--clear_lead=0"
+  "--generate_static_mpd"
+  "--mpd_output=${OUTPUT_DIR}/manifest.mpd"
+  "--hls_master_playlist_output=${OUTPUT_DIR}/master.m3u8"
+  "--protection_scheme=cenc"
+  "--base_urls=${PACKAGER_BASE_URL}"
+)
+
+if [[ -n "${DRM_PSSH_BASE64}" ]]; then
+  COMMON_PARAMS+=("--pssh=${DRM_PSSH_BASE64}")
+fi
+
+"${SHAKA_BIN}" \
+  "in=${INPUT_VIDEO},stream=video,output=${OUTPUT_DIR}/${STREAM_LABEL}.mp4" \
+  "in=${INPUT_AUDIO},stream=audio,output=${OUTPUT_DIR}/${AUDIO_LABEL}.mp4" \
+  "${COMMON_PARAMS[@]}"
+
+cat <<INFO
+Shaka packaging complete.
+DASH manifest: ${OUTPUT_DIR}/manifest.mpd
+HLS playlist: ${OUTPUT_DIR}/master.m3u8
+DRM license URL: ${DRM_LICENSE_URL}
+INFO


### PR DESCRIPTION
## Summary
- add FFmpeg helper script that derives its configuration from environment variables and DRM placeholders
- add Shaka Packager helper with configurable stream metadata and DRM key variables
- document required environment variables for both packager scripts

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dbd0a957bc8328af2fab9dc9832da3