### PR TITLE
Integrate routing engine into proxy route selection

### DIFF
--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -38,7 +38,7 @@ async fn health_endpoint_returns_success() {
         }],
     };
 
-    let state = build_app_state(&config);
+    let state = build_app_state(&config).expect("app state should build");
     let router = app::build_router(state);
 
     let listener_cfg = primary_listener(&config).expect("listener should be available");


### PR DESCRIPTION
## Summary
- extend the application state to hold a shared routing engine alongside existing caches
- compile route definitions from configuration when building application state and reuse the engine during proxy forwarding
- update proxy routing logic, helpers, and tests to exercise glob, protocol, and port matching scenarios

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68dbfee222888328af4ceb31ce4d7f7b