### PR TITLE
Add Docker container build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.6
+
+FROM rust:1.76-slim AS builder
+WORKDIR /app
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY config ./config
+COPY scripts ./scripts
+RUN cargo fetch --locked
+
+# Copy the rest of the source tree and build the release binary
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/target/release/sProx /usr/local/bin/sprox
+COPY config ./config
+
+ENV RUST_LOG=info \
+    RUST_BACKTRACE=1
+
+EXPOSE 8080
+ENTRYPOINT ["sprox"]
+CMD ["--config", "config/routes.yaml"]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ added as the implementation matures. For interim guidance consult
      `cargo run -- --config config/routes.yaml`.
    - Use tools like `curl` or [`hurl`](https://hurl.dev/) to validate basic proxying.
 
+## Containerized workflow
+
+Build and run the proxy in a container to match production-like deployments or to
+avoid installing the Rust toolchain locally:
+
+```bash
+# Build the optimized image
+docker build -t sprox:latest .
+
+# Run the container, exposing the default listener and mounting local configs
+docker run --rm \
+  -p 8080:8080 \
+  -v "$(pwd)/config:/app/config:ro" \
+  sprox:latest --config config/routes.yaml
+```
+
+The `scripts/docker-run.sh` helper automates the build/run workflow. It produces a
+local `sprox:local` image (override with `IMAGE_NAME`) and starts the container with
+the configuration directory mounted read-only:
+
+```bash
+./scripts/docker-run.sh
+```
+
+Pass any additional arguments after the script invocation to forward them to the
+containerized binary (for example `./scripts/docker-run.sh --config config/routes.yaml`).
+
 ## Repository layout
 
 ```

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-sprox:local}"
+CONTAINER_NAME="${CONTAINER_NAME:-sprox}"
+CONFIG_PATH="${CONFIG_PATH:-${REPO_ROOT}/config}"
+
+pushd "${REPO_ROOT}" >/dev/null
+
+echo "Building image ${IMAGE_NAME}..."
+docker build -t "${IMAGE_NAME}" .
+
+echo "Starting container ${CONTAINER_NAME}..."
+docker run --rm \
+    --name "${CONTAINER_NAME}" \
+    -p "8080:8080" \
+    -v "${CONFIG_PATH}:/app/config:ro" \
+    "${IMAGE_NAME}" "$@"
+
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the release binary and packages it into a slim runtime image
- add a .dockerignore and helper script to streamline local Docker builds
- document containerized build and run steps in the README

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc0c054d88832885d669f879c80747