### PR TITLE
Add FFmpeg and Shaka Packager to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,16 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS runtime
+
+ARG SHAKA_PACKAGER_VERSION=v2.6.1
+ARG SHAKA_PACKAGER_SHA256=328317e8f12dbcf9a5a172704699c2da51e54feb68cec5787666c2ab07b2c88d
+
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg \
+    && curl -fsSL "https://github.com/shaka-project/shaka-packager/releases/download/${SHAKA_PACKAGER_VERSION}/packager-linux-x64" -o /usr/local/bin/packager \
+    && echo "${SHAKA_PACKAGER_SHA256}  /usr/local/bin/packager" | sha256sum -c - \
+    && chmod +x /usr/local/bin/packager \
+    && ln -s /usr/local/bin/packager /usr/local/bin/shaka-packager \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/packagers/README.md
+++ b/packagers/README.md
@@ -5,6 +5,21 @@ streaming pipeline. Each script is intentionally verbose about the
 environment variables it expects so that the automation driving them can
 source values from a secrets manager or `.env` file.
 
+## Bundled binaries
+
+The official Docker image produced from this repository now bundles the
+following utilities so the helper scripts can run without additional
+setup:
+
+- **FFmpeg 5.1.4-0+deb12u1** (from Debian bookworm) is installed at
+  `/usr/bin/ffmpeg` and available via the default `PATH`.
+- **Shaka Packager v2.6.1** is installed as `/usr/local/bin/packager` with a
+  `shaka-packager` symlink for convenience.
+
+Deployments that rely on these images can invoke the scripts directly, or set
+`FFMPEG_BIN` / `SHAKA_BIN` to override the bundled versions when newer builds
+are desired.
+
 ## `ffmpeg_packager.sh`
 
 Encrypts a mezzanine file using FFmpeg's Common Encryption support. The script


### PR DESCRIPTION
## Summary
- install FFmpeg alongside the runtime proxy image and download a pinned Shaka Packager release
- expose the packager binary on PATH with a convenience symlink
- document the bundled toolchain and override expectations for deployments

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc3e4e7a9c83289ca8b78711308a00