### PR TITLE
Add clear-mode option to packager helpers

### DIFF
--- a/packagers/README.md
+++ b/packagers/README.md
@@ -30,9 +30,10 @@ expects the following variables to be exported before invocation:
 - `FFMPEG_OUTPUT_DIR` – Directory where encrypted assets will be stored.
 - `FFMPEG_VIDEO_BITRATE` *(optional)* – Target video bitrate (default: `3500k`).
 - `FFMPEG_AUDIO_BITRATE` *(optional)* – Target audio bitrate (default: `128k`).
-- `DRM_KEY_ID` – Hex-encoded key identifier (KID).
-- `DRM_KEY_HEX` – Hex-encoded AES key.
-- `DRM_IV_HEX` *(optional)* – Initialization vector override; defaults to all zeros.
+- `DRM_MODE` *(optional)* – Set to `disabled` to skip DRM entirely (default: `enabled`).
+- `DRM_KEY_ID` – Hex-encoded key identifier (KID). Required when `DRM_MODE=enabled`.
+- `DRM_KEY_HEX` – Hex-encoded AES key. Required when `DRM_MODE=enabled`.
+- `DRM_IV_HEX` *(optional)* – Initialization vector override; defaults to all zeros when DRM is enabled.
 
 ## `shaka_packager.sh`
 
@@ -46,14 +47,19 @@ variables include:
 - `STREAM_LABEL` *(optional)* – Label assigned to the video stream (default: `video`).
 - `AUDIO_LABEL` *(optional)* – Label assigned to the audio stream (default: `audio`).
 - `PACKAGER_BASE_URL` *(optional)* – Base URL advertised in the generated manifests.
-- `DRM_KEY_ID` – Hex-encoded key identifier.
-- `DRM_KEY_HEX` – Hex-encoded AES key.
-- `DRM_PSSH_BASE64` *(optional)* – Base64 encoded custom PSSH box to embed.
+- `DRM_MODE` *(optional)* – Set to `disabled` for clear output (default: `enabled`).
+- `DRM_KEY_ID` – Hex-encoded key identifier. Required when `DRM_MODE=enabled`.
+- `DRM_KEY_HEX` – Hex-encoded AES key. Required when `DRM_MODE=enabled`.
+- `DRM_PSSH_BASE64` *(optional)* – Base64 encoded custom PSSH box to embed when DRM is enabled.
 - `DRM_CONTENT_ID` *(optional)* – Identifier used in Widevine requests (default: `sprox-demo`).
-- `DRM_LICENSE_URL` – URL of the license proxy / DRM provider.
+- `DRM_LICENSE_URL` – URL of the license proxy / DRM provider. Required when `DRM_MODE=enabled`.
 
 Scripts can be invoked directly after exporting the variables or sourcing an
 `.env` file. Example:
+
+### Examples
+
+**Encrypted output with FFmpeg**
 
 ```bash
 export FFMPEG_INPUT=assets/mezzanine.mp4
@@ -61,6 +67,37 @@ export FFMPEG_OUTPUT_DIR=./build/ffmpeg
 export DRM_KEY_ID=0123456789abcdef0123456789abcdef
 export DRM_KEY_HEX=abcdef0123456789abcdef0123456789
 ./packagers/ffmpeg_packager.sh
+```
+
+**Clear output with FFmpeg**
+
+```bash
+export FFMPEG_INPUT=assets/mezzanine.mp4
+export FFMPEG_OUTPUT_DIR=./build/ffmpeg
+export DRM_MODE=disabled
+./packagers/ffmpeg_packager.sh
+```
+
+**Encrypted output with Shaka Packager**
+
+```bash
+export INPUT_VIDEO=assets/video.mp4
+export INPUT_AUDIO=assets/audio.m4a
+export OUTPUT_DIR=./build/shaka
+export DRM_KEY_ID=0123456789abcdef0123456789abcdef
+export DRM_KEY_HEX=abcdef0123456789abcdef0123456789
+export DRM_LICENSE_URL=https://license.example.com
+./packagers/shaka_packager.sh
+```
+
+**Clear output with Shaka Packager**
+
+```bash
+export INPUT_VIDEO=assets/video.mp4
+export INPUT_AUDIO=assets/audio.m4a
+export OUTPUT_DIR=./build/shaka
+export DRM_MODE=disabled
+./packagers/shaka_packager.sh
 ```
 
 Because the scripts use `set -euo pipefail`, they will fail fast whenever a

--- a/packagers/ffmpeg_packager.sh
+++ b/packagers/ffmpeg_packager.sh
@@ -6,35 +6,70 @@ set -euo pipefail
 # be sourced from an environment file (e.g. `source ./config/packaging.env`).
 
 : "${FFMPEG_BIN:=ffmpeg}"            # Override to point to a custom FFmpeg build
-: "${FFMPEG_INPUT:?Need to set FFMPEG_INPUT to the mezzanine file}" 
-: "${FFMPEG_OUTPUT_DIR:?Need to set FFMPEG_OUTPUT_DIR to the output directory}" 
+: "${FFMPEG_INPUT:?Need to set FFMPEG_INPUT to the mezzanine file}"
+: "${FFMPEG_OUTPUT_DIR:?Need to set FFMPEG_OUTPUT_DIR to the output directory}"
 : "${FFMPEG_VIDEO_BITRATE:=3500k}"  # Example video bitrate
 : "${FFMPEG_AUDIO_BITRATE:=128k}"   # Example audio bitrate
+: "${DRM_MODE:=enabled}"            # Set to "disabled" for clear output
 
-# DRM placeholders. Replace these with your Widevine/PlayReady keys or point
-# to a secrets manager before running the script.
-: "${DRM_KEY_ID:?Need to set DRM_KEY_ID}"         # e.g. 0123456789abcdef0123456789abcdef
-: "${DRM_KEY_HEX:?Need to set DRM_KEY_HEX}"       # Raw AES-128 key in hex
-: "${DRM_IV_HEX:=00000000000000000000000000000000}" # Optional IV override
+case "${DRM_MODE}" in
+  enabled|disabled) ;;
+  *)
+    echo "Unsupported DRM_MODE '${DRM_MODE}'. Use 'enabled' or 'disabled'." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  # DRM placeholders. Replace these with your Widevine/PlayReady keys or point
+  # to a secrets manager before running the script.
+  : "${DRM_KEY_ID:?Need to set DRM_KEY_ID}"         # e.g. 0123456789abcdef0123456789abcdef
+  : "${DRM_KEY_HEX:?Need to set DRM_KEY_HEX}"       # Raw AES-128 key in hex
+  : "${DRM_IV_HEX:=00000000000000000000000000000000}" # Optional IV override
+fi
 
 mkdir -p "${FFMPEG_OUTPUT_DIR}"
 
-"${FFMPEG_BIN}" \
-  -y \
-  -i "${FFMPEG_INPUT}" \
-  -c:v libx264 \
-  -b:v "${FFMPEG_VIDEO_BITRATE}" \
-  -c:a aac \
-  -b:a "${FFMPEG_AUDIO_BITRATE}" \
-  -movflags +faststart \
-  -encryption_scheme cenc-aes-ctr \
-  -encryption_key "${DRM_KEY_HEX}" \
-  -encryption_kid "${DRM_KEY_ID}" \
-  -encryption_iv "${DRM_IV_HEX}" \
-  "${FFMPEG_OUTPUT_DIR}/encrypted_output.mp4"
+FFMPEG_CMD=(
+  "${FFMPEG_BIN}"
+  -y
+  -i "${FFMPEG_INPUT}"
+  -c:v libx264
+  -b:v "${FFMPEG_VIDEO_BITRATE}"
+  -c:a aac
+  -b:a "${FFMPEG_AUDIO_BITRATE}"
+  -movflags +faststart
+)
 
-cat <<INFO
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  FFMPEG_CMD+=(
+    -encryption_scheme cenc-aes-ctr
+    -encryption_key "${DRM_KEY_HEX}"
+    -encryption_kid "${DRM_KEY_ID}"
+    -encryption_iv "${DRM_IV_HEX}"
+  )
+fi
+
+OUTPUT_FILENAME="encrypted_output.mp4"
+if [[ "${DRM_MODE}" == "disabled" ]]; then
+  OUTPUT_FILENAME="clear_output.mp4"
+fi
+
+FFMPEG_CMD+=("${FFMPEG_OUTPUT_DIR}/${OUTPUT_FILENAME}")
+
+"${FFMPEG_CMD[@]}"
+
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  cat <<INFO
 Packaging complete.
-Encrypted output stored at: ${FFMPEG_OUTPUT_DIR}/encrypted_output.mp4
+Output stored at: ${FFMPEG_OUTPUT_DIR}/${OUTPUT_FILENAME}
+DRM mode: ${DRM_MODE}
 Used DRM key ID: ${DRM_KEY_ID}
 INFO
+else
+  cat <<INFO
+Packaging complete.
+Output stored at: ${FFMPEG_OUTPUT_DIR}/${OUTPUT_FILENAME}
+DRM mode: ${DRM_MODE}
+INFO
+fi

--- a/packagers/shaka_packager.sh
+++ b/packagers/shaka_packager.sh
@@ -6,38 +6,58 @@ set -euo pipefail
 # before running the script.
 
 : "${SHAKA_BIN:=packager}"             # Override to point to the packager binary
-: "${INPUT_VIDEO:?Set INPUT_VIDEO to the source video file}" 
-: "${INPUT_AUDIO:?Set INPUT_AUDIO to the source audio file}" 
-: "${OUTPUT_DIR:?Set OUTPUT_DIR to the directory for DASH/HLS outputs}" 
+: "${INPUT_VIDEO:?Set INPUT_VIDEO to the source video file}"
+: "${INPUT_AUDIO:?Set INPUT_AUDIO to the source audio file}"
+: "${OUTPUT_DIR:?Set OUTPUT_DIR to the directory for DASH/HLS outputs}"
 : "${STREAM_LABEL:=video}"             # Label used in the manifest for video
 : "${AUDIO_LABEL:=audio}"              # Label used in the manifest for audio
 : "${PACKAGER_BASE_URL:=https://cdn.example.com/}" # Base URL advertised in the manifests
+: "${DRM_MODE:=enabled}"               # Set to "disabled" for clear output
 
-# DRM placeholders. Replace these with the actual values provided by your DRM
-# provider. They can also be injected securely via environment variables in CI.
-: "${DRM_KEY_ID:?Set DRM_KEY_ID (hex)}"
-: "${DRM_KEY_HEX:?Set DRM_KEY_HEX (hex)}"
-: "${DRM_PSSH_BASE64:=}"               # Optional custom PSSH data (base64)
-: "${DRM_CONTENT_ID:=sprox-demo}"     # Used for Widevine license requests
-: "${DRM_LICENSE_URL:?Set DRM_LICENSE_URL}" # e.g. https://license.example.com
+case "${DRM_MODE}" in
+  enabled|disabled) ;;
+  *)
+    echo "Unsupported DRM_MODE '${DRM_MODE}'. Use 'enabled' or 'disabled'." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  # DRM placeholders. Replace these with the actual values provided by your DRM
+  # provider. They can also be injected securely via environment variables in CI.
+  : "${DRM_KEY_ID:?Set DRM_KEY_ID (hex)}"
+  : "${DRM_KEY_HEX:?Set DRM_KEY_HEX (hex)}"
+  : "${DRM_PSSH_BASE64:=}"               # Optional custom PSSH data (base64)
+  : "${DRM_CONTENT_ID:=sprox-demo}"     # Used for Widevine license requests
+  : "${DRM_LICENSE_URL:?Set DRM_LICENSE_URL}" # e.g. https://license.example.com
+else
+  : "${DRM_CONTENT_ID:=sprox-demo}"     # Still set for message consistency
+  DRM_LICENSE_URL=""
+  DRM_KEY_ID=""
+fi
 
 mkdir -p "${OUTPUT_DIR}"
 
 COMMON_PARAMS=(
-  "--enable_raw_key_encryption"
-  "--key_id=${DRM_KEY_ID}"
-  "--key=${DRM_KEY_HEX}"
-  "--content_id=${DRM_CONTENT_ID}"
-  "--clear_lead=0"
   "--generate_static_mpd"
   "--mpd_output=${OUTPUT_DIR}/manifest.mpd"
   "--hls_master_playlist_output=${OUTPUT_DIR}/master.m3u8"
-  "--protection_scheme=cenc"
   "--base_urls=${PACKAGER_BASE_URL}"
 )
 
-if [[ -n "${DRM_PSSH_BASE64}" ]]; then
-  COMMON_PARAMS+=("--pssh=${DRM_PSSH_BASE64}")
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  COMMON_PARAMS+=(
+    "--enable_raw_key_encryption"
+    "--key_id=${DRM_KEY_ID}"
+    "--key=${DRM_KEY_HEX}"
+    "--content_id=${DRM_CONTENT_ID}"
+    "--clear_lead=0"
+    "--protection_scheme=cenc"
+  )
+
+  if [[ -n "${DRM_PSSH_BASE64}" ]]; then
+    COMMON_PARAMS+=("--pssh=${DRM_PSSH_BASE64}")
+  fi
 fi
 
 "${SHAKA_BIN}" \
@@ -45,9 +65,19 @@ fi
   "in=${INPUT_AUDIO},stream=audio,output=${OUTPUT_DIR}/${AUDIO_LABEL}.mp4" \
   "${COMMON_PARAMS[@]}"
 
-cat <<INFO
+if [[ "${DRM_MODE}" != "disabled" ]]; then
+  cat <<INFO
 Shaka packaging complete.
 DASH manifest: ${OUTPUT_DIR}/manifest.mpd
 HLS playlist: ${OUTPUT_DIR}/master.m3u8
+DRM mode: ${DRM_MODE}
 DRM license URL: ${DRM_LICENSE_URL}
 INFO
+else
+  cat <<INFO
+Shaka packaging complete.
+DASH manifest: ${OUTPUT_DIR}/manifest.mpd
+HLS playlist: ${OUTPUT_DIR}/master.m3u8
+DRM mode: ${DRM_MODE}
+INFO
+fi


### PR DESCRIPTION
## Summary
- add a DRM_MODE toggle to the FFmpeg and Shaka packager helper scripts so they support clear and encrypted runs
- adjust command construction to skip DRM flags when disabled and improve user-facing status messages
- document the new workflows in packagers/README.md with DRM and clear usage examples

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc408a7bcc8328871817cdd810c587