### PR TITLE
Add DRM feature flag to gate Clear Key endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ default = [
     "http-proxy",
     "config-loader",
     "telemetry",
+    "drm",
 ]
 
 # Enable core HTTP proxy stack built on Axum/Tower.
@@ -34,6 +35,9 @@ telemetry = [
     "dep:metrics",
     "dep:metrics-exporter-prometheus",
 ]
+
+# Enable DRM-specific functionality such as Clear Key handling.
+drm = ["http-proxy"]
 
 # Feature flag placeholders for upcoming media tooling.
 streaming-hls = ["dep:bytes"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ added as the implementation matures. For interim guidance consult
    - Once the binary exposes runtime flags, start the proxy with
      `cargo run -- --config config/routes.yaml`.
 
+### Cargo feature flags
+
+- `drm` – Enables DRM-specific functionality, including the Clear Key JWKS endpoint
+  and associated secret store plumbing. The flag is enabled by default to preserve the
+  existing developer experience, but Real-Debrid/AllDebrid style deployments should
+  disable it to avoid exposing DRM routes. Build with
+  `cargo build --no-default-features --features "http-proxy config-loader telemetry"`
+  (or the subset of features you require) to run without DRM support.
+
 ## Environment variables
 
 The proxy reads sensitive runtime configuration from environment variables. Copy


### PR DESCRIPTION
## Summary
- add a `drm` Cargo feature (enabled by default) to control compilation of Clear Key support
- guard the Clear Key route, handler, helpers, and tests so they are only compiled when the DRM feature is enabled
- document the new feature flag and note that debrid-style deployments should disable it by default

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc4285cf488328a8605c013cd08240