### PR TITLE
Add direct stream configuration and enforce API password

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ dotenvy = "0.15"
 sha2 = "0.10"
 subtle = "2.5"
 uuid = { version = "1", features = ["std"] }
+once_cell = "1.21"
 
 [dev-dependencies]
 serde_json = { version = "1.0" }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -59,3 +59,8 @@ routes:
       rewrite_playlist_urls: false
       base_url: null
       allow_insecure_segments: false
+direct_stream:
+  proxy_url: null                # Optional HTTP proxy used for direct stream requests.
+  api_password: null             # Optional shared secret required when invoking the endpoint.
+  request_timeout_ms: 30000      # Timeout applied to upstream requests issued by the direct client.
+  response_buffer_bytes: 65536   # Initial HTTP/2 window sizes used when streaming responses.

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -23,6 +23,7 @@ use sProx::config::{Config, ListenerConfig, RouteConfig, Socks5Config, TlsConfig
 #[tokio::test]
 async fn health_endpoint_returns_success() {
     let config = Config {
+        direct_stream: None,
         routes: vec![RouteConfig {
             id: "health-check".into(),
             listen: ListenerConfig {
@@ -124,6 +125,7 @@ async fn socks5_proxy_env_override_applies_to_all_routes() {
         };
 
     let config = Config {
+        direct_stream: None,
         routes: vec![
             route_template("disabled-proxy", false, None),
             route_template("enabled-proxy", true, Some("10.0.0.1:9000")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,12 +115,18 @@ fn build_app_state(config: &Config) -> Result<AppState> {
 
     let routing_engine = Arc::new(RoutingEngine::new(route_definitions)?);
 
-    Ok(AppState::with_components(
+    let mut state = AppState::with_components(
         Arc::new(RwLock::new(HashMap::new())),
         Arc::new(RwLock::new(routing_table)),
         Arc::new(RwLock::new(HashMap::new())),
         routing_engine,
-    ))
+    );
+
+    if let Some(direct_stream) = config.direct_stream.clone() {
+        state = state.with_direct_stream_settings(direct_stream.into());
+    }
+
+    Ok(state)
 }
 
 fn primary_listener(config: &Config) -> Option<&ListenerConfig> {


### PR DESCRIPTION
## Summary
- add an optional direct_stream section with environment overrides to the configuration loader
- extend AppState with shared direct-stream settings and a lazily built proxied client
- require the configured API password before handling direct stream requests and adjust tests/docs

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc51b95ce08328aed6d00e833bcfcb