### PR TITLE
Enforce direct stream safety policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ playback compatibility. Standard HTTP range semantics apply: a successful partia
 returns `206 Partial Content` with the appropriate `Content-Range`, while full responses
 return `200 OK` alongside the upstream `Content-Length`.
 
+Direct stream destinations must be explicitly allowlisted in configuration. Each entry
+in `direct_stream.allowlist` specifies the domain, permitted schemes, and optional path
+globs that are allowed to be proxied. For example:
+
+```yaml
+direct_stream:
+  allowlist:
+    - domain: "media.example.com"
+      schemes: ["https"]
+      paths:
+        - "/vod/**"
+```
+
+Requests to destinations that do not match the allowlist, use non-HTTP(S) schemes, or
+resolve to private/link-local networks are rejected with `403 Forbidden` before any
+upstream connection is made. Header overrides that fall outside of the built-in request
+allowlist now yield `400 Bad Request`, providing explicit feedback to callers that an
+override is disallowed.
+
 ## Local development
 
 1. **Install prerequisites**


### PR DESCRIPTION
## Summary
- add configuration structures for direct-stream allowlists and redirect policy wiring
- enforce scheme/IP allowlist validation for direct streaming and header overrides
- expand integration tests and documentation covering allowlisted and blocked targets

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dc804b8d8c8328afbc8b2de169f26c