### PR TITLE
Enforce direct stream IP restrictions via DNS resolver

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -383,6 +383,10 @@ fn build_direct_stream_client(settings: &DirectStreamSettings) -> Result<Client,
         .timeout(settings.request_timeout())
         .redirect(RedirectPolicy::none());
 
+    let resolver = Arc::new(crate::stream::direct::RestrictedDnsResolver::new());
+
+    builder = builder.dns_resolver(resolver);
+
     if let Some(proxy_url) = settings.proxy_url() {
         builder = builder.proxy(Proxy::all(proxy_url.as_str())?);
     }


### PR DESCRIPTION
## Summary
- ensure direct stream requests use a DNS resolver that filters restricted IP addresses
- remove preflight host resolution and map resolver rejections to destination restriction errors
- register the restricted resolver on the direct stream client so all outbound connections reuse the validated addresses

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dd1e7812148328bb602d79bf32eb37