### PR TITLE
Add configurable retry policies and budgets to outbound requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.38", features = ["rt-multi-thread", "macros", "signal", "process"] }
-tower = { version = "0.4", features = ["util", "limit"], optional = true }
+tower = { version = "0.4", features = ["util", "limit", "retry"], optional = true }
 tower-http = { version = "0.5", features = ["trace"], optional = true }
 tracing = { version = "0.1", features = ["std"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"], optional = true }

--- a/README.md
+++ b/README.md
@@ -79,10 +79,14 @@ Key configuration concepts:
 
 - **Listeners** – Control the transport protocol (HTTP/1.1, HTTP/2, QUIC), TLS settings
   for inbound traffic, and concurrency limits (to be implemented).
-- **Upstreams** – Describe where traffic is proxied, including TLS requirements,
-  optional SOCKS5 tunnelling, and retry budgets. Setting the `SPROX_PROXY_URL`
-  environment variable at runtime forces every route to tunnel through the
-  provided SOCKS5 endpoint regardless of the per-route configuration.
+- **Upstreams** – Describe where traffic is proxied, including per-hop timeout
+  knobs (connect/read/request), TLS requirements, optional SOCKS5 tunnelling,
+  and retry budgets. By default, retries allow three attempts with exponential
+  backoff starting at 100 ms (doubling up to 5 s) and 20 % jitter while the
+  budget replenishes over a 10 s window (20 % of requests may be retried with a
+  minimum reserve of 10 per second). Setting the `SPROX_PROXY_URL` environment
+  variable at runtime forces every route to tunnel through the provided SOCKS5
+  endpoint regardless of the per-route configuration.
 - **Streaming toggles** – Enable playlist rewriting, segment URL translation, DRM key
   acquisition, and future transcoding jobs.
 - **Environment overrides** – Sensitive values (API tokens, TLS private keys) are loaded

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod security;
 pub mod state;
 pub mod stream;
 pub use stream::direct;
+mod retry;
 #[cfg(feature = "telemetry")]
 mod telemetry;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ fn build_app_state(config: &Config) -> Result<AppState> {
             tls_insecure_skip_verify: route.upstream.tls.insecure_skip_verify,
             socks5,
             hls,
+            retry: route.upstream.retry.clone().into(),
         };
 
         routing_table.insert(route.id.clone(), target);

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,203 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::future::BoxFuture;
+use rand::Rng;
+use reqwest::{Client, Request, Response};
+use tower::retry::{budget::Budget, Policy};
+use tower::{retry::Retry, Service};
+
+use crate::state::RetryPolicy;
+
+/// Error returned when a retryable operation exhausts its attempts.
+#[derive(Debug)]
+pub enum RetryError {
+    /// The underlying request failed even after all retry attempts were exhausted.
+    Request(reqwest::Error),
+    /// The retry budget rejected the attempt, signalling that the circuit is open.
+    BudgetExhausted { source: reqwest::Error },
+}
+
+impl RetryError {
+    pub fn into_source(self) -> reqwest::Error {
+        match self {
+            RetryError::Request(source) => source,
+            RetryError::BudgetExhausted { source } => source,
+        }
+    }
+
+    pub fn is_budget_exhausted(&self) -> bool {
+        matches!(self, RetryError::BudgetExhausted { .. })
+    }
+}
+
+impl From<reqwest::Error> for RetryError {
+    fn from(source: reqwest::Error) -> Self {
+        RetryError::Request(source)
+    }
+}
+
+/// Executes the provided request using the supplied retry policy.
+pub(crate) async fn execute_with_retry(
+    client: Client,
+    request: Request,
+    policy: RetryPolicy,
+) -> Result<Response, RetryError> {
+    let shared_policy = Arc::new(SharedPolicy::new(policy));
+    shared_policy.budget.deposit();
+
+    let retry_policy = ExponentialBackoffPolicy::new(shared_policy.clone());
+    let mut retry_service = Retry::new(retry_policy, ReqwestService::new(client));
+
+    match retry_service.call(request).await {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            if shared_policy.circuit_open.load(Ordering::SeqCst) {
+                Err(RetryError::BudgetExhausted { source: error })
+            } else {
+                Err(RetryError::Request(error))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ExponentialBackoffPolicy {
+    shared: Arc<SharedPolicy>,
+    attempt: u32,
+}
+
+impl ExponentialBackoffPolicy {
+    fn new(shared: Arc<SharedPolicy>) -> Self {
+        Self { shared, attempt: 1 }
+    }
+}
+
+impl Policy<Request, Response, reqwest::Error> for ExponentialBackoffPolicy {
+    type Future = Pin<Box<dyn Future<Output = Self> + Send>>;
+
+    fn retry(
+        &self,
+        request: &Request,
+        result: Result<&Response, &reqwest::Error>,
+    ) -> Option<Self::Future> {
+        match result {
+            Ok(_) => None,
+            Err(error) => {
+                if !self.shared.should_retry(request, error) {
+                    return None;
+                }
+
+                if self.attempt >= self.shared.max_attempts() {
+                    return None;
+                }
+
+                if self.shared.budget.withdraw().is_err() {
+                    self.shared.circuit_open.store(true, Ordering::SeqCst);
+                    return None;
+                }
+
+                let delay = self.shared.backoff_delay(self.attempt);
+                let shared = self.shared.clone();
+                let next_attempt = self.attempt + 1;
+
+                Some(Box::pin(async move {
+                    tokio::time::sleep(delay).await;
+                    Self {
+                        shared,
+                        attempt: next_attempt,
+                    }
+                }))
+            }
+        }
+    }
+
+    fn clone_request(&self, request: &Request) -> Option<Request> {
+        request.try_clone()
+    }
+}
+
+struct SharedPolicy {
+    policy: RetryPolicy,
+    budget: Arc<Budget>,
+    circuit_open: Arc<AtomicBool>,
+}
+
+impl SharedPolicy {
+    fn new(policy: RetryPolicy) -> Self {
+        let budget = policy.budget_handle();
+        Self {
+            policy,
+            budget,
+            circuit_open: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn should_retry(&self, request: &Request, error: &reqwest::Error) -> bool {
+        if !self.policy.is_method_retryable(request.method()) {
+            return false;
+        }
+
+        if error.is_timeout() || error.is_connect() {
+            return true;
+        }
+
+        if error.is_request() {
+            return true;
+        }
+
+        // Treat transport layer errors that bubble up as retryable by default.
+        error.is_body() || error.is_decode()
+    }
+
+    fn max_attempts(&self) -> u32 {
+        self.policy.max_attempts().get()
+    }
+
+    fn backoff_delay(&self, attempt: u32) -> Duration {
+        let base = self.policy.backoff_delay(attempt);
+        let jitter = self.policy.backoff_jitter();
+        if jitter <= f64::EPSILON {
+            return base;
+        }
+
+        let mut rng = rand::thread_rng();
+        let jitter_range = (1.0 - jitter).max(0.0)..=(1.0 + jitter);
+        let factor: f64 = rng.gen_range(jitter_range);
+        base.mul_f64(factor)
+    }
+}
+
+#[derive(Clone)]
+struct ReqwestService {
+    client: Client,
+}
+
+impl ReqwestService {
+    fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Service<Request> for ReqwestService {
+    type Response = Response;
+    type Error = reqwest::Error;
+    type Future = BoxFuture<'static, Result<Response, reqwest::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let client = self.client.clone();
+        Box::pin(async move { client.execute(request).await })
+    }
+}


### PR DESCRIPTION
## Summary
- add per-hop timeout and retry configuration to route targets and direct stream settings
- introduce a shared retry executor with exponential backoff, jitter, and budget tracking for outbound requests
- document new configuration knobs and cover retry behaviour with integration tests

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dd2acb53f88328aae08283b52ba6c4