### PR TITLE
Add TTL-aware secrets store and sensitive logging configuration

### DIFF
--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -23,7 +23,8 @@ use url::Url;
 
 use sProx::config::{
     Config, DirectStreamAllowRule, DirectStreamAllowlist, DirectStreamConfig, DirectStreamScheme,
-    ListenerConfig, RetryConfig, RouteConfig, Socks5Config, TlsConfig, UpstreamConfig,
+    ListenerConfig, RetryConfig, RouteConfig, SecretsConfig, SensitiveLoggingConfig, Socks5Config,
+    TlsConfig, UpstreamConfig,
 };
 use sProx::state::{AppState, DirectStreamSettings};
 
@@ -59,6 +60,8 @@ async fn health_endpoint_returns_success() {
             },
             hls: None,
         }],
+        secrets: SecretsConfig::default(),
+        sensitive_logging: SensitiveLoggingConfig::default(),
     };
 
     let state = build_app_state(&config).expect("app state should build");
@@ -139,6 +142,8 @@ async fn socks5_proxy_env_override_applies_to_all_routes() {
             route_template("disabled-proxy", false, None),
             route_template("enabled-proxy", true, Some("10.0.0.1:9000")),
         ],
+        secrets: SecretsConfig::default(),
+        sensitive_logging: SensitiveLoggingConfig::default(),
     };
 
     let state = build_app_state(&config).expect("app state should build");

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use sProx::{
     app,
     config::{Config, ListenerConfig},
     routing::{PortRange, RouteDefinition, RoutingEngine},
-    state::{AppState, HlsOptions, RouteTarget, Socks5Proxy},
+    state::{AppState, HlsOptions, RouteTarget, SecretsStore, Socks5Proxy},
 };
 use tokio::{net::TcpListener, sync::RwLock};
 
@@ -119,13 +119,15 @@ fn build_app_state(config: &Config) -> Result<AppState> {
     let mut state = AppState::with_components(
         Arc::new(RwLock::new(HashMap::new())),
         Arc::new(RwLock::new(routing_table)),
-        Arc::new(RwLock::new(HashMap::new())),
+        Arc::new(RwLock::new(SecretsStore::new(config.secrets.default_ttl))),
         routing_engine,
     );
 
     if let Some(direct_stream) = config.direct_stream.clone() {
         state = state.with_direct_stream_settings(direct_stream.into());
     }
+
+    state = state.with_sensitive_logging(config.sensitive_logging.clone().into());
 
     Ok(state)
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -647,7 +647,7 @@ fn prepare_upstream_headers(
 mod tests {
     use super::*;
     use crate::routing::{PortRange, RouteDefinition, RouteProtocol, RouteRequest, RoutingEngine};
-    use crate::state::RetryPolicy;
+    use crate::state::{RetryPolicy, SecretsStore};
     use axum::http::header::HeaderValue;
     use axum::http::{HeaderMap, Request, Uri};
     use reqwest::header::HeaderName as ReqHeaderName;
@@ -781,7 +781,7 @@ mod tests {
         AppState::with_components(
             Arc::new(RwLock::new(HashMap::new())),
             Arc::new(RwLock::new(targets)),
-            Arc::new(RwLock::new(HashMap::new())),
+            Arc::new(RwLock::new(SecretsStore::default())),
             Arc::new(
                 RoutingEngine::new(definitions).expect("routing engine should compile for tests"),
             ),


### PR DESCRIPTION
## Summary
- replace the in-memory secrets HashMap with a TTL-aware store that refuses serialization and wire its default TTL through configuration
- add sensitive logging toggles to state/configuration and redact ClearKey requests in the trace span when logging is disabled
- expand ClearKey and configuration tests to cover TTL expiry, redaction defaults, and configuration parsing updates

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dd410057d88328a6042bab755b4e1e