### PR TITLE
Implement configurable header policy handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ hyper = { version = "0.14", features = ["full"], optional = true }
 reqwest = { version = "=0.11.26", default-features = false, features = ["json", "stream", "rustls-tls"], optional = true }
 aes-gcm = { version = "0.10", features = ["aes"], optional = false }
 base64 = "0.21"
+http = "1"
 hmac = "0.12"
 ipnet = "2.9"
 rand = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn build_app_state(config: &Config) -> Result<AppState> {
             socks5,
             hls,
             retry: route.upstream.retry.clone().into(),
+            header_policy: route.upstream.header_policy.clone().into(),
         };
 
         routing_table.insert(route.id.clone(), target);


### PR DESCRIPTION
## Summary
- add header policy configuration with X-Forwarded-For controls and allow/deny lists
- enforce header policy in the proxy when forwarding requests and responses, normalizing Via headers
- add integration coverage to verify hop-by-hop stripping and header forwarding policy toggles

## Testing
- cargo fmt
- cargo clippy --all-targets
- cargo test
- cargo build


------
https://chatgpt.com/codex/tasks/task_e_68dd4ce12f3483288da636715add3e9d