### PR TITLE
Add telemetry instrumentation and metrics

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -56,6 +56,18 @@ fn init_metrics() -> Result<()> {
         "Latency histogram (in seconds) for HTTP responses emitted by the proxy."
     );
     metrics::describe_counter!(
+        "sprox_requests_total",
+        "Total number of upstream requests issued by the proxy, labelled by route."
+    );
+    metrics::describe_histogram!(
+        "sprox_upstream_latency_seconds",
+        "Latency histogram (in seconds) for upstream requests grouped by route."
+    );
+    metrics::describe_counter!(
+        "sprox_bytes_streamed_total",
+        "Total number of response bytes streamed back to clients from upstream services."
+    );
+    metrics::describe_counter!(
         "sprox_health_checks_total",
         "Total number of successful /health responses served."
     );


### PR DESCRIPTION
## Summary
- attach request identifiers, upstream metadata, retry counters, and response byte counts to proxy and direct stream logs
- register and emit Prometheus counters/histograms for upstream requests, latency, and streamed bytes; expose /metrics even without telemetry
- add telemetry integration tests that validate exported metrics series

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68dd5a0fcaa08328a3ea49f6652c9221