### PR TITLE
Add CLI validation and SIGHUP reload support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,9 @@ streaming-dash = []
 
 [dependencies]
 anyhow = "1.0"
+arc-swap = "1.7"
 axum = { version = "0.7", default-features = false, features = ["http1", "http2", "json", "macros", "tokio", "query", "original-uri"], optional = true }
+clap = { version = "4.5", features = ["derive"] }
 bytes = { version = "1.5", optional = true }
 config = { version = "0.13", default-features = false, features = ["yaml", "toml"], optional = true }
 futures = "0.3"
@@ -79,7 +81,10 @@ uuid = { version = "1", features = ["std"] }
 once_cell = "1.21"
 
 [dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
 serde_json = { version = "1.0" }
 serde_yaml = { version = "0.9" }
 tokio = { version = "1.38", features = ["macros", "rt"] }
+tempfile = "3.10"
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ performance characteristics:
   - Monitor CPU utilisation of manifest processing routines; heavy transmuxing should be
     offloaded to dedicated media workers when possible.
 
+### Configuration validation and reloads
+
+- Use the built-in CLI to validate configuration bundles before deploying. Running
+  `cargo run -- validate -c config` (or the installed binary `sprox validate -c <dir>`) reads
+  `<dir>/routes.yaml` with the same loader used at runtime and reports any syntax or
+  semantic validation errors without starting the server.
+- The runtime watches for `SIGHUP` on Unix targets. Sending `kill -HUP <pid>` forces sProx
+  to reload the configuration from disk, rebuild the application state, and atomically
+  swap it into the running server. If validation fails the previous configuration is
+  retained, with failures logged to aid debugging.
+- When the `SPROX_CONFIG` environment variable is set the daemon and the validation
+  command both honour it, allowing alternate configuration directories or files to be
+  tested and reloaded.
+
 Further operational playbooks (disaster recovery, observability, canary rollouts) will be
 added as the implementation matures. For interim guidance consult
 [`docs/operational-notes.md`](docs/operational-notes.md).

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,22 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn validate_command_accepts_valid_configuration() {
+    let temp = TempDir::new().expect("temp dir should create");
+    let config_path = temp.path().join("routes.yaml");
+    fs::copy("config/routes.yaml", config_path).expect("config file should copy");
+
+    Command::cargo_bin("sProx")
+        .expect("binary should compile")
+        .args([
+            "validate",
+            "-c",
+            temp.path().to_str().expect("path should stringify"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("configuration at"));
+}

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -1,0 +1,115 @@
+use std::fs;
+
+use sProx::{
+    config::Config,
+    state::{reload_app_state_from_path, AppState, SharedAppState},
+};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+const INITIAL_CONFIG: &str = r#"
+routes:
+  - id: "alpha"
+    listen:
+      host: "127.0.0.1"
+      port: 8080
+    host_patterns: []
+    protocols: ["http"]
+    upstream:
+      origin: "http://initial.example.com"
+"#;
+
+const UPDATED_CONFIG: &str = r#"
+routes:
+  - id: "alpha"
+    listen:
+      host: "127.0.0.1"
+      port: 8080
+    host_patterns: []
+    protocols: ["http"]
+    upstream:
+      origin: "https://updated.example.com"
+"#;
+
+const INVALID_CONFIG: &str = r#"
+routes:
+  - id: "alpha"
+    listen:
+      host: "127.0.0.1"
+      port: 8080
+    host_patterns: []
+    protocols: ["http"]
+    upstream:
+      tls:
+        enabled: true
+"#;
+
+#[test]
+fn reload_replaces_state_on_success() {
+    let runtime = Runtime::new().expect("runtime should start");
+    let temp = TempDir::new().expect("temp dir should create");
+    let config_path = temp.path().join("routes.yaml");
+    fs::write(&config_path, INITIAL_CONFIG).expect("config should write");
+
+    let config = Config::load_from_path(&config_path).expect("config should load");
+    let shared = SharedAppState::new(AppState::from_config(&config).expect("state should build"));
+
+    runtime.block_on(async {
+        assert_eq!(
+            current_upstream(&shared).await,
+            "http://initial.example.com"
+        );
+    });
+
+    fs::write(&config_path, UPDATED_CONFIG).expect("config should update");
+    reload_app_state_from_path(&config_path, &shared).expect("reload should succeed");
+
+    runtime.block_on(async {
+        assert_eq!(
+            current_upstream(&shared).await,
+            "https://updated.example.com"
+        );
+    });
+}
+
+#[test]
+fn reload_preserves_state_when_validation_fails() {
+    let runtime = Runtime::new().expect("runtime should start");
+    let temp = TempDir::new().expect("temp dir should create");
+    let config_path = temp.path().join("routes.yaml");
+    fs::write(&config_path, INITIAL_CONFIG).expect("config should write");
+
+    let config = Config::load_from_path(&config_path).expect("config should load");
+    let shared = SharedAppState::new(AppState::from_config(&config).expect("state should build"));
+
+    runtime.block_on(async {
+        assert_eq!(
+            current_upstream(&shared).await,
+            "http://initial.example.com"
+        );
+    });
+
+    fs::write(&config_path, INVALID_CONFIG).expect("config should update");
+    let result = reload_app_state_from_path(&config_path, &shared);
+    assert!(result.is_err(), "reload should fail for invalid config");
+
+    runtime.block_on(async {
+        assert_eq!(
+            current_upstream(&shared).await,
+            "http://initial.example.com"
+        );
+    });
+}
+
+async fn current_upstream(state: &SharedAppState) -> String {
+    let snapshot = state.snapshot();
+    let table = snapshot.routing_table();
+    let guard = table.read().await;
+    guard
+        .values()
+        .next()
+        .expect("route should exist")
+        .upstream
+        .trim_end_matches('/')
+        .to_string()
+}


### PR DESCRIPTION
## Summary
- add a clap-based CLI with a `validate` subcommand so configurations can be checked without starting the server
- introduce a reloadable application state, wire a SIGHUP watcher, and ensure reloads roll back on validation failure
- document the workflow and add smoke tests covering the validation command and live reload behaviour

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test --all-features
- cargo build --all-features

------
https://chatgpt.com/codex/tasks/task_e_68dd6a6a835c8328affa5f342155e572