### PR TITLE
Refine container image for distroless runtime and add healthcheck CLI

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -6,6 +6,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 IMAGE_NAME="${IMAGE_NAME:-sprox:local}"
 CONTAINER_NAME="${CONTAINER_NAME:-sprox}"
 CONFIG_PATH="${CONFIG_PATH:-${REPO_ROOT}/config}"
+DOTENV_PATH="${DOTENV_PATH:-${REPO_ROOT}/.env}"
+EXTRA_MOUNTS=()
+
+if [[ -f "${DOTENV_PATH}" ]]; then
+    EXTRA_MOUNTS+=("--mount" "type=bind,src=${DOTENV_PATH},dst=/app/.env,readonly")
+fi
 
 pushd "${REPO_ROOT}" >/dev/null
 
@@ -16,7 +22,8 @@ echo "Starting container ${CONTAINER_NAME}..."
 docker run --rm \
     --name "${CONTAINER_NAME}" \
     -p "8080:8080" \
-    -v "${CONFIG_PATH}:/app/config:ro" \
+    --mount "type=bind,src=${CONFIG_PATH},dst=/config,readonly" \
+    "${EXTRA_MOUNTS[@]}" \
     "${IMAGE_NAME}" "$@"
 
 popd >/dev/null

--- a/src/config.rs
+++ b/src/config.rs
@@ -1299,6 +1299,13 @@ mod tests {
 
     #[test]
     fn direct_stream_defaults_to_none_without_overrides() {
+        let _guard = env_lock().lock().expect("env lock should be acquired");
+
+        env::remove_var("SPROX_DIRECT_PROXY_URL");
+        env::remove_var("SPROX_DIRECT_API_PASSWORD");
+        env::remove_var("SPROX_DIRECT_REQUEST_TIMEOUT_MS");
+        env::remove_var("SPROX_DIRECT_RESPONSE_BUFFER_BYTES");
+
         let raw = RawConfig {
             direct_stream: None,
             routes: vec![sample_route()],


### PR DESCRIPTION
## Summary
- refactor the Docker image into a multi-stage build that installs FFmpeg/Shaka Packager once and copies the binaries and TLS assets into a distroless runtime
- run the service as a non-root user, expose a built-in healthcheck, and document the new mount points and CLI workflow
- add a `sprox healthcheck` subcommand plus supporting test guardrails and update the docker-run helper to mount config and env files read-only

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dd769d29908328a8ccbd2aab362a9a