### PR TITLE
Fix Docker entrypoint default arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ["/usr/local/bin/sprox", "healthcheck", "--url", "http://127.0.0.1:8080/health"]
 
 ENTRYPOINT ["/usr/local/bin/sprox"]
-CMD ["--config", "/config/routes.yaml"]


### PR DESCRIPTION
## Summary
- remove the default `--config` command arguments from the Docker image so the service starts with the environment-provided configuration

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68dd8dba6ff08328957d1e6b87d5214a