### PR TITLE
chore: upgrade toolchain to Rust 1.81

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.81.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- update the toolchain override to Rust 1.81 so the workspace builds with recent transitive dependencies

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68df26b54d6883289939aa7f4677fccb