### PR TITLE
Bind upstream requests to SSRF-validated DNS

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -5,6 +5,7 @@ pub mod ssrf;
 
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::body::Body;
@@ -841,6 +842,7 @@ fn build_client(route: &RouteTarget) -> Result<Client, ProxyError> {
     let mut builder = Client::builder()
         .redirect(Policy::none())
         .danger_accept_invalid_certs(route.tls_insecure_skip_verify);
+    builder = builder.dns_resolver(Arc::new(ssrf::GuardedDnsResolver));
     builder = apply_client_timeouts(builder, route);
 
     if let Some(proxy) = &route.socks5 {


### PR DESCRIPTION
## Summary
- add a reqwest DNS resolver that reuses the SSRF guard to vet resolved addresses
- configure proxy clients to use the guarded resolver so outbound connections honor the validation
- cover the new resolver with targeted unit tests

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dfc18c80748328aab8832e6001f6ba