### PR TITLE
Preserve upstream Content-Type headers

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -430,10 +430,10 @@ pub async fn forward(
         let mut updated = false;
         for (name, value) in header_entries.iter_mut() {
             if name == &CONTENT_TYPE {
-                let should_update = value
-                    .to_str()
-                    .map(|existing| !existing.eq_ignore_ascii_case(guessed_type))
-                    .unwrap_or(true);
+                let should_update = match value.to_str() {
+                    Ok(existing) => existing.trim().is_empty(),
+                    Err(_) => true,
+                };
                 if should_update {
                     *value = HeaderValue::from_static(guessed_type);
                 }


### PR DESCRIPTION
## Summary
- avoid overwriting upstream Content-Type headers when they already contain a usable value

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68dfed78aef48328882f574f869c0016