### PR TITLE
Add proxy stream auth guard, concurrency limiter, and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ The proxy reads sensitive runtime configuration from environment variables. Copy
 * `SPROX_DIRECT_PROXY_URL` – Override the HTTP proxy used by `/proxy/stream` requests.
 * `SPROX_DIRECT_API_PASSWORD` – Inject the shared secret required for `/proxy/stream`
   without modifying configuration files.
+* `SPROX_API_PASSWORD` – Require `Authorization: Bearer` tokens for `/proxy/stream`
+  requests and other protected routes.
 * `SPROX_DIRECT_REQUEST_TIMEOUT_MS` – Override the direct stream request timeout in
   milliseconds.
 * `SPROX_DIRECT_RESPONSE_BUFFER_BYTES` – Override the initial HTTP/2 receive window for

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -71,6 +71,26 @@ fn init_metrics() -> Result<()> {
         "sprox_health_checks_total",
         "Total number of successful /health responses served."
     );
+    metrics::describe_counter!(
+        "sprox_proxy_stream_requests_total",
+        "Total number of /proxy/stream responses emitted grouped by HTTP status."
+    );
+    metrics::describe_counter!(
+        "sprox_proxy_stream_upstream_status_total",
+        "Total number of upstream responses observed by /proxy/stream grouped by status."
+    );
+    metrics::describe_counter!(
+        "sprox_proxy_stream_bytes_out_total",
+        "Total bytes streamed to clients via /proxy/stream grouped by status."
+    );
+    metrics::describe_histogram!(
+        "sprox_proxy_stream_first_byte_latency_seconds",
+        "Latency histogram (in seconds) for time-to-first-byte observed by /proxy/stream."
+    );
+    metrics::describe_histogram!(
+        "sprox_proxy_stream_duration_seconds",
+        "Latency histogram (in seconds) for full request duration of /proxy/stream."
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add global API password support loaded from `SPROX_API_PASSWORD` and document the new environment variable
- protect `/proxy/stream` with bearer authentication, a concurrency semaphore, and streaming metrics instrumentation
- expand integration tests for authorization, concurrency saturation, and metrics while extending upstream test helpers

## Testing
- cargo fmt
- cargo clippy
- cargo test
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68e00f9b64e08328869bfb971a99f449